### PR TITLE
Fix bug with add_args context

### DIFF
--- a/src/statue/__main__.py
+++ b/src/statue/__main__.py
@@ -122,7 +122,7 @@ def list_commands(
         print(command.name, "-", command.help)
 
 
-@statue.command()
+@statue.command("install")
 @click.pass_obj
 @contexts_option
 @allow_option
@@ -130,7 +130,7 @@ def list_commands(
 @verbosity_option
 @silent_option
 @verbose_option
-def install(
+def install_commands(
     statue_configuration: MutableMapping[str, Any],
     context: Optional[List[str]],
     allow: Optional[List[str]],
@@ -160,7 +160,7 @@ def install(
 )
 @verbosity_option
 @silent_option
-@verbose_option
+@verbose_option  # pylint: disable=R0913
 def run(
     ctx: click.Context,
     sources: List[Union[Path, str]],
@@ -222,4 +222,4 @@ def run(
 
 
 if __name__ == "__main__":
-    statue()
+    statue()  # pylint: disable=E1120

--- a/src/statue/commands_reader.py
+++ b/src/statue/commands_reader.py
@@ -60,7 +60,7 @@ def __skip_command(
 
 
 def __read_args(setups: dict, contexts: List[str]):
-    base_args = setups.get(ARGS, [])
+    base_args = list(setups.get(ARGS, []))
     for command_context in contexts:
         context_obj = setups.get(command_context, None)
         if not isinstance(context_obj, dict):

--- a/tests/readers/test_commands_reader.py
+++ b/tests/readers/test_commands_reader.py
@@ -29,17 +29,17 @@ def test_read_empty_settings(empty_settings):
     assert commands == []
 
 
-def test_read_settings_with_one_command_without_args(one_command_setting):
+def test_read_commands_with_one_command_without_args(one_command_setting):
     commands = read_commands(one_command_setting)
     assert commands == [Command(name=COMMAND1, help=HELP_STRING1)]
 
 
-def test_read_settings_with_one_command_with_args(one_command_with_args_settings):
+def test_read_commands_with_one_command_with_args(one_command_with_args_settings):
     commands = read_commands(one_command_with_args_settings)
     assert commands == [Command(name=COMMAND1, help=HELP_STRING1, args=[ARG1, ARG2])]
 
 
-def test_read_settings_with_multiple_commands(
+def test_read_commands_with_multiple_commands(
     full_commands_settings_with_boolean_contexts,
 ):
     commands = read_commands(full_commands_settings_with_boolean_contexts)
@@ -51,7 +51,7 @@ def test_read_settings_with_multiple_commands(
     ]
 
 
-def test_read_settings_with_non_passing_context(
+def test_read_commands_with_non_passing_context(
     full_commands_settings_with_boolean_contexts,
 ):
     commands = read_commands(
@@ -60,7 +60,7 @@ def test_read_settings_with_non_passing_context(
     assert commands == []
 
 
-def test_read_settings_with_one_passing_context(
+def test_read_commands_with_one_passing_context(
     full_commands_settings_with_boolean_contexts,
 ):
     commands = read_commands(
@@ -69,7 +69,7 @@ def test_read_settings_with_one_passing_context(
     assert commands == [Command(name=COMMAND3, help=HELP_STRING3)]
 
 
-def test_read_settings_with_two_passing_context(
+def test_read_commands_with_two_passing_context(
     full_commands_settings_with_boolean_contexts,
 ):
     commands = read_commands(
@@ -81,7 +81,7 @@ def test_read_settings_with_two_passing_context(
     ]
 
 
-def test_read_settings_with_two_contexts(full_commands_settings_with_boolean_contexts):
+def test_read_commands_with_two_contexts(full_commands_settings_with_boolean_contexts):
     commands = read_commands(
         full_commands_settings_with_boolean_contexts, contexts=[CONTEXT1, CONTEXT2]
     )
@@ -90,7 +90,7 @@ def test_read_settings_with_two_contexts(full_commands_settings_with_boolean_con
     ]
 
 
-def test_read_settings_with_non_standard_command(
+def test_read_commands_with_non_standard_command(
     full_commands_settings_with_boolean_contexts,
 ):
     commands = read_commands(
@@ -101,7 +101,7 @@ def test_read_settings_with_non_standard_command(
     ]
 
 
-def test_read_settings_with_overrides_without_contexts(
+def test_read_commands_with_overrides_without_contexts(
     full_commands_settings_with_override_contexts,
 ):
     commands = read_commands(full_commands_settings_with_override_contexts)
@@ -110,7 +110,7 @@ def test_read_settings_with_overrides_without_contexts(
     ]
 
 
-def test_read_settings_with_overrides_with_context(
+def test_read_commands_with_overrides_with_context(
     full_commands_settings_with_override_contexts,
 ):
     commands = read_commands(
@@ -121,7 +121,7 @@ def test_read_settings_with_overrides_with_context(
     ]
 
 
-def test_read_settings_with_overrides_with_another_context(
+def test_read_commands_with_overrides_with_another_context(
     full_commands_settings_with_override_contexts,
 ):
     commands = read_commands(
@@ -132,7 +132,7 @@ def test_read_settings_with_overrides_with_another_context(
     ]
 
 
-def test_read_settings_with_overrides_with_clear_args_context(
+def test_read_commands_with_overrides_with_clear_args_context(
     full_commands_settings_with_override_contexts,
 ):
     commands = read_commands(
@@ -143,7 +143,7 @@ def test_read_settings_with_overrides_with_clear_args_context(
     ]
 
 
-def test_read_settings_with_overrides_with_add_args_context(
+def test_read_commands_with_overrides_with_add_args_context(
     full_commands_settings_with_override_contexts,
 ):
     commands = read_commands(
@@ -151,6 +151,21 @@ def test_read_settings_with_overrides_with_add_args_context(
     )
     assert commands == [
         Command(name=COMMAND1, help=HELP_STRING1, args=[ARG1, ARG2, ARG5]),
+    ]
+
+
+def test_read_commands_twice_with_overrides_with_add_args_context(
+    full_commands_settings_with_override_contexts,
+):
+    commands1 = read_commands(
+        full_commands_settings_with_override_contexts, contexts=[CONTEXT4]
+    )
+    assert commands1 == [
+        Command(name=COMMAND1, help=HELP_STRING1, args=[ARG1, ARG2, ARG5]),
+    ]
+    commands2 = read_commands(full_commands_settings_with_override_contexts)
+    assert commands2 == [
+        Command(name=COMMAND1, help=HELP_STRING1, args=[ARG1, ARG2]),
     ]
 
 


### PR DESCRIPTION
When trying to read a command with add_args context and then no context, the added argument is kept.