### PR TITLE
Command execute return evaluation

### DIFF
--- a/src/statue/cli/config.py
+++ b/src/statue/cli/config.py
@@ -11,7 +11,7 @@ import toml
 from statue.cli.cli import statue_cli
 from statue.cli.util import allow_option, contexts_option, deny_option, verbose_option
 from statue.configuration import Configuration
-from statue.constants import COMMANDS, CONTEXTS, SOURCES, VERSION
+from statue.constants import COMMANDS, CONTEXTS, SOURCES, VERSION, ENCODING
 from statue.sources_finder import expend, find_sources
 
 YES = ["y", "yes"]
@@ -72,7 +72,7 @@ def init_config_cli(directory, interactive):
         interactive=interactive,
     )
     with open(
-        Configuration.configuration_path(directory), mode="w", encoding="utf-8"
+        Configuration.configuration_path(directory), mode="w", encoding=ENCODING
     ) as config_file:
         toml.dump({SOURCES: sources_map}, config_file)
 
@@ -129,7 +129,7 @@ def fixate_commands_versions(
     if len(commands_list) == 0:
         click.echo("No commands to fixate.")
         return
-    with open(configuration_path, mode="r", encoding="utf-8") as config_file:
+    with open(configuration_path, mode="r", encoding=ENCODING) as config_file:
         raw_config_dict = toml.load(config_file)
     if COMMANDS not in raw_config_dict:
         raw_config_dict[COMMANDS] = {}
@@ -141,7 +141,7 @@ def fixate_commands_versions(
         if command.name not in raw_config_dict[COMMANDS]:
             raw_config_dict[COMMANDS][command.name] = {}
         raw_config_dict[COMMANDS][command.name][VERSION] = command.installed_version
-    with open(configuration_path, mode="w", encoding="utf-8") as config_file:
+    with open(configuration_path, mode="w", encoding=ENCODING) as config_file:
         toml.dump(raw_config_dict, config_file)
 
 

--- a/src/statue/cli/config.py
+++ b/src/statue/cli/config.py
@@ -11,7 +11,7 @@ import toml
 from statue.cli.cli import statue_cli
 from statue.cli.util import allow_option, contexts_option, deny_option, verbose_option
 from statue.configuration import Configuration
-from statue.constants import COMMANDS, CONTEXTS, SOURCES, VERSION, ENCODING
+from statue.constants import COMMANDS, CONTEXTS, ENCODING, SOURCES, VERSION
 from statue.sources_finder import expend, find_sources
 
 YES = ["y", "yes"]

--- a/src/statue/cli/history.py
+++ b/src/statue/cli/history.py
@@ -8,8 +8,9 @@ import click
 from statue.cache import Cache
 from statue.cli.cli import statue_cli
 from statue.cli.util import bullet_style, failure_style, success_style
+from statue.command import CommandEvaluation
 from statue.constants import DATETIME_FORMAT
-from statue.evaluation import CommandEvaluation, Evaluation
+from statue.evaluation import Evaluation
 
 
 def evaluation_status(evaluation: Union[Evaluation, CommandEvaluation]) -> str:

--- a/src/statue/cli/run.py
+++ b/src/statue/cli/run.py
@@ -18,9 +18,10 @@ from statue.cli.util import (
     verbosity_option,
 )
 from statue.commands_map import read_commands_map
-from statue.evaluation import Evaluation, evaluate_commands_map
+from statue.evaluation import Evaluation
 from statue.exceptions import MissingConfiguration, UnknownContext
 from statue.print_util import print_boxed
+from statue.runner import evaluate_commands_map
 from statue.verbosity import is_silent
 
 

--- a/src/statue/command.py
+++ b/src/statue/command.py
@@ -4,13 +4,50 @@ import importlib
 import os
 import subprocess  # nosec
 import sys
-from dataclasses import dataclass, field
-from typing import List, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
 
 import pkg_resources
 
 from statue.exceptions import CommandExecutionError
 from statue.verbosity import DEFAULT_VERBOSITY, is_silent, is_verbose
+
+
+@dataclass
+class CommandEvaluation:
+    """Evaluation result of a command."""
+
+    command: "Command"
+    success: bool
+
+    def as_json(self) -> Dict[str, Any]:
+        """
+        Return command evaluation as json dictionary.
+
+        :return: Self as dictionary
+        :rtype: Dict[str, Any]
+        """
+        command_json = {
+            key: value
+            for key, value in asdict(self.command).items()
+            if value is not None
+        }
+        return dict(command=command_json, success=self.success)
+
+    @classmethod
+    def from_json(cls, command_evaluation: Dict[str, Any]) -> "CommandEvaluation":
+        """
+        Read command evaluation from json dictionary.
+
+        :param command_evaluation: Json command evaluation
+        :type command_evaluation: Dict[str, Any]
+        :return: Parsed command evaluation
+        :rtype: CommandEvaluation
+        """
+        return CommandEvaluation(
+            command=Command(**command_evaluation["command"]),
+            success=command_evaluation["success"],
+        )
 
 
 @dataclass

--- a/src/statue/command.py
+++ b/src/statue/command.py
@@ -196,7 +196,7 @@ class Command:
         self,
         source: str,
         verbosity: str = DEFAULT_VERBOSITY,
-    ) -> int:
+    ) -> CommandEvaluation:
         """
         Execute the command.
 
@@ -204,8 +204,8 @@ class Command:
         :type: str
         :param verbosity: Indicates the verbosity of the prints to console.
         :type verbosity: str
-        :return: Exit code of the command
-        :rtype: int
+        :return: Command's evaluation including the command itself and is it successful
+        :rtype: CommandEvaluation
         """
         args = [self.name, source, *self.args]
         if is_verbose(verbosity):
@@ -223,14 +223,15 @@ class Command:
             return True
         return self.installed_version == self.version
 
-    def _run_subprocess(self, args: List[str], verbosity: str) -> int:
+    def _run_subprocess(self, args: List[str], verbosity: str) -> CommandEvaluation:
         try:
-            return subprocess.run(  # nosec
+            exit_code = subprocess.run(  # nosec
                 args,
                 env=os.environ,
                 check=False,
                 capture_output=is_silent(verbosity),
             ).returncode
+            return CommandEvaluation(command=self, success=(exit_code == 0))
         except FileNotFoundError as error:
             raise CommandExecutionError(self.name) from error
 

--- a/src/statue/constants.py
+++ b/src/statue/constants.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 
 STATUE = "STATUE"
+ENCODING = "utf-8"
 
 HISTORY_SIZE = 30
 

--- a/src/statue/evaluation.py
+++ b/src/statue/evaluation.py
@@ -1,6 +1,6 @@
 """Evaluation of commands map."""
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, ItemsView, Iterator, KeysView, List, Union
 

--- a/src/statue/evaluation.py
+++ b/src/statue/evaluation.py
@@ -2,11 +2,9 @@
 import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, ItemsView, Iterator, KeysView, List, Union
+from typing import Any, Dict, ItemsView, Iterator, KeysView, List, Union
 
 from statue.command import Command
-from statue.print_util import print_title
-from statue.verbosity import DEFAULT_VERBOSITY, is_silent
 
 
 @dataclass
@@ -325,38 +323,3 @@ class Evaluation:
                 for input_path, source_evaluation in evaluation.items()
             }
         )
-
-
-def evaluate_commands_map(
-    commands_map: Dict[str, List[Command]],
-    verbosity: str = DEFAULT_VERBOSITY,
-    print_method: Callable[..., None] = print,
-) -> Evaluation:
-    """
-    Run commands map and return evaluation report.
-
-    :param commands_map: map from input file to list of commands to run on it,
-    :type commands_map: Dict[str, List[Command]],
-    :param verbosity: verbosity level
-    :type verbosity: str
-    :param print_method: print method, can be either ``print`` or ``click.echo``
-    :type print_method: Callable
-    :return: Evaluation
-    """
-    evaluation = Evaluation()
-    for input_path, commands in commands_map.items():
-        source_evaluation = SourceEvaluation()
-        if not is_silent(verbosity):
-            print_method("")
-            print_method("")
-            print_title(input_path, transform=False, print_method=print_method)
-            print_method("")
-        for command in commands:
-            if not is_silent(verbosity):
-                print_title(command.name, underline="-", print_method=print_method)
-            success = command.execute(input_path, verbosity) == 0
-            source_evaluation.commands_evaluations.append(
-                CommandEvaluation(command=command, success=success)
-            )
-        evaluation[input_path] = source_evaluation
-    return evaluation

--- a/src/statue/evaluation.py
+++ b/src/statue/evaluation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, ItemsView, Iterator, KeysView, List, Union
 
 from statue.command import Command, CommandEvaluation
+from statue.constants import ENCODING
 
 
 @dataclass
@@ -163,7 +164,7 @@ class Evaluation:
         :param output: Path to save self in
         :type output: Path or str
         """
-        with open(output, mode="w", encoding="utf-8") as output_file:
+        with open(output, mode="w", encoding=ENCODING) as output_file:
             json.dump(self.as_json(), output_file, indent=2)
 
     @property
@@ -229,7 +230,7 @@ class Evaluation:
         :return: Evaluation instance
         :rtype: Evaluation
         """
-        with open(input_path, mode="r", encoding="utf-8") as input_file:
+        with open(input_path, mode="r", encoding=ENCODING) as input_file:
             return Evaluation.from_json(json.load(input_file))
 
     @property

--- a/src/statue/evaluation.py
+++ b/src/statue/evaluation.py
@@ -4,44 +4,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, ItemsView, Iterator, KeysView, List, Union
 
-from statue.command import Command
-
-
-@dataclass
-class CommandEvaluation:
-    """Evaluation result of a command."""
-
-    command: Command
-    success: bool
-
-    def as_json(self) -> Dict[str, Any]:
-        """
-        Return command evaluation as json dictionary.
-
-        :return: Self as dictionary
-        :rtype: Dict[str, Any]
-        """
-        command_json = {
-            key: value
-            for key, value in asdict(self.command).items()
-            if value is not None
-        }
-        return dict(command=command_json, success=self.success)
-
-    @classmethod
-    def from_json(cls, command_evaluation: Dict[str, Any]) -> "CommandEvaluation":
-        """
-        Read command evaluation from json dictionary.
-
-        :param command_evaluation: Json command evaluation
-        :type command_evaluation: Dict[str, Any]
-        :return: Parsed command evaluation
-        :rtype: CommandEvaluation
-        """
-        return CommandEvaluation(
-            command=Command(**command_evaluation["command"]),
-            success=command_evaluation["success"],
-        )
+from statue.command import Command, CommandEvaluation
 
 
 @dataclass

--- a/src/statue/runner.py
+++ b/src/statue/runner.py
@@ -1,0 +1,42 @@
+"""Command map runner."""
+from typing import Callable, Dict, List
+
+from statue.command import Command
+from statue.evaluation import CommandEvaluation, Evaluation, SourceEvaluation
+from statue.print_util import print_title
+from statue.verbosity import DEFAULT_VERBOSITY, is_silent
+
+
+def evaluate_commands_map(
+    commands_map: Dict[str, List[Command]],
+    verbosity: str = DEFAULT_VERBOSITY,
+    print_method: Callable[..., None] = print,
+) -> Evaluation:
+    """
+    Run commands map and return evaluation report.
+
+    :param commands_map: map from input file to list of commands to run on it,
+    :type commands_map: Dict[str, List[Command]],
+    :param verbosity: verbosity level
+    :type verbosity: str
+    :param print_method: print method, can be either ``print`` or ``click.echo``
+    :type print_method: Callable
+    :return: Evaluation
+    """
+    evaluation = Evaluation()
+    for input_path, commands in commands_map.items():
+        source_evaluation = SourceEvaluation()
+        if not is_silent(verbosity):
+            print_method("")
+            print_method("")
+            print_title(input_path, transform=False, print_method=print_method)
+            print_method("")
+        for command in commands:
+            if not is_silent(verbosity):
+                print_title(command.name, underline="-", print_method=print_method)
+            success = command.execute(input_path, verbosity) == 0
+            source_evaluation.commands_evaluations.append(
+                CommandEvaluation(command=command, success=success)
+            )
+        evaluation[input_path] = source_evaluation
+    return evaluation

--- a/src/statue/runner.py
+++ b/src/statue/runner.py
@@ -34,9 +34,8 @@ def evaluate_commands_map(
         for command in commands:
             if not is_silent(verbosity):
                 print_title(command.name, underline="-", print_method=print_method)
-            success = command.execute(input_path, verbosity) == 0
             source_evaluation.commands_evaluations.append(
-                CommandEvaluation(command=command, success=success)
+                command.execute(input_path, verbosity)
             )
         evaluation[input_path] = source_evaluation
     return evaluation

--- a/src/statue/runner.py
+++ b/src/statue/runner.py
@@ -2,7 +2,7 @@
 from typing import Callable, Dict, List
 
 from statue.command import Command
-from statue.evaluation import CommandEvaluation, Evaluation, SourceEvaluation
+from statue.evaluation import Evaluation, SourceEvaluation
 from statue.print_util import print_title
 from statue.verbosity import DEFAULT_VERBOSITY, is_silent
 

--- a/tests/cli/test_run_cli.py
+++ b/tests/cli/test_run_cli.py
@@ -21,13 +21,13 @@ from tests.util import command_mock
 def build_commands_map():
     return {
         SOURCE1: [
-            command_mock(name=COMMAND1, return_code=0),
-            command_mock(name=COMMAND2, return_code=0),
+            command_mock(name=COMMAND1),
+            command_mock(name=COMMAND2),
         ],
         SOURCE2: [
-            command_mock(name=COMMAND1, return_code=0),
-            command_mock(name=COMMAND3, return_code=0),
-            command_mock(name=COMMAND4, return_code=0),
+            command_mock(name=COMMAND1),
+            command_mock(name=COMMAND3),
+            command_mock(name=COMMAND4),
         ],
     }
 
@@ -75,9 +75,9 @@ def test_run_with_no_cache(
 def test_run_and_install_uninstalled_commands(
     cli_runner, mock_read_commands_map, mock_cache_save_evaluation, mock_cwd
 ):
-    command1 = command_mock(COMMAND1, installed=True, return_code=0)
-    command2 = command_mock(COMMAND2, installed=False, return_code=0)
-    command3 = command_mock(COMMAND3, installed=True, return_code=0)
+    command1 = command_mock(COMMAND1, installed=True)
+    command2 = command_mock(COMMAND2, installed=False)
+    command3 = command_mock(COMMAND3, installed=True)
     mock_read_commands_map.return_value = {
         SOURCE1: [command1, command2],
         SOURCE2: [command3],
@@ -216,18 +216,18 @@ def test_run_has_failed(
 ):
     commands_map = {
         SOURCE1: [
-            command_mock(name=COMMAND1, return_code=0),
-            command_mock(name=COMMAND2, return_code=1),
+            command_mock(name=COMMAND1),
+            command_mock(name=COMMAND2, success=False),
         ],
         SOURCE2: [
-            command_mock(name=COMMAND1, return_code=0),
-            command_mock(name=COMMAND3, return_code=1),
-            command_mock(name=COMMAND4, return_code=0),
+            command_mock(name=COMMAND1),
+            command_mock(name=COMMAND3, success=False),
+            command_mock(name=COMMAND4),
         ],
     }
     failure_map = {
-        SOURCE1: [command_mock(name=COMMAND2, return_code=1)],
-        SOURCE2: [command_mock(name=COMMAND3, return_code=1)],
+        SOURCE1: [command_mock(name=COMMAND2, success=False)],
+        SOURCE2: [command_mock(name=COMMAND3, success=False)],
     }
     mock_read_commands_map.return_value = commands_map
 
@@ -296,9 +296,9 @@ def test_run_with_none_commands_map(
 def test_run_uninstalled_command(
     cli_runner, mock_read_commands_map, mock_cache_save_evaluation, mock_cwd
 ):
-    command1 = command_mock(COMMAND1, installed=True, return_code=0)
-    command2 = command_mock(COMMAND2, installed=False, return_code=0)
-    command3 = command_mock(COMMAND3, installed=True, return_code=0)
+    command1 = command_mock(COMMAND1, installed=True)
+    command2 = command_mock(COMMAND2, installed=False)
+    command3 = command_mock(COMMAND3, installed=True)
     mock_read_commands_map.return_value = {
         SOURCE1: [command1, command2],
         SOURCE2: [command3],

--- a/tests/cli/test_run_cli.py
+++ b/tests/cli/test_run_cli.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 from pytest_cases import fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,19 @@ from statue.evaluation import Evaluation
 ENVIRON = dict(s=2, d=5, g=8)
 
 
+# 3rd Party Mocks
+
+
+@pytest.fixture
+def mock_time(mocker):
+    return mocker.patch("time.time")
+
+
+@pytest.fixture
+def mock_subprocess(mocker):
+    return mocker.patch("subprocess.run")
+
+
 @pytest.fixture
 def mock_toml_load(mocker):
     return mocker.patch("toml.load")
@@ -21,6 +34,9 @@ def mock_toml_load(mocker):
 @pytest.fixture
 def mock_toml_dump(mocker):
     return mocker.patch("toml.dump")
+
+
+# Configuration Mocks
 
 
 @pytest.fixture
@@ -86,14 +102,7 @@ def empty_configuration(mock_cwd, clear_configuration):
     return configuration
 
 
-@pytest.fixture
-def mock_time(mocker):
-    return mocker.patch("time.time")
-
-
-@pytest.fixture
-def mock_subprocess(mocker):
-    return mocker.patch("subprocess.run")
+# Command Mocks
 
 
 @pytest.fixture
@@ -101,14 +110,12 @@ def mock_get_package(mocker):
     return mocker.patch.object(Command, "_get_package")
 
 
+# Cache Mocks
+
+
 @pytest.fixture
 def mock_cache_save_evaluation(mocker):
     return mocker.patch.object(Cache, "save_evaluation")
-
-
-@pytest.fixture
-def mock_evaluation_load_from_file(mocker):
-    return mocker.patch.object(Evaluation, "load_from_file")
 
 
 @pytest.fixture
@@ -124,6 +131,17 @@ def mock_cache_all_evaluation_paths(mocker):
 @pytest.fixture
 def mock_cache_recent_evaluation_path(mocker):
     return mocker.patch.object(Cache, "recent_evaluation_path")
+
+
+# Evaluation Mocks
+
+
+@pytest.fixture
+def mock_evaluation_load_from_file(mocker):
+    return mocker.patch.object(Evaluation, "load_from_file")
+
+
+# Built-in Mocks
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,11 @@ def mock_evaluation_load_from_file(mocker):
     return mocker.patch.object(Evaluation, "load_from_file")
 
 
+@pytest.fixture
+def mock_evaluation_save_as_json(mocker):
+    return mocker.patch.object(Evaluation, "save_as_json")
+
+
 # Built-in Mocks
 
 

--- a/tests/evaluation/test_evaluate_commands_map.py
+++ b/tests/evaluation/test_evaluate_commands_map.py
@@ -16,7 +16,7 @@ def case_empty_commands_map():
 
 
 def case_one_source_one_command():
-    command1 = command_mock(COMMAND1, return_code=0)
+    command1 = command_mock(COMMAND1)
     commands_map = {SOURCE1: [command1]}
 
     evaluation = Evaluation()
@@ -37,8 +37,8 @@ def case_one_source_one_command():
 
 
 def case_one_source_two_commands():
-    command1 = command_mock(COMMAND1, return_code=0)
-    command2 = command_mock(COMMAND2, return_code=1)
+    command1 = command_mock(COMMAND1)
+    command2 = command_mock(COMMAND2, success=False)
     commands_map = {SOURCE1: [command1, command2]}
 
     evaluation = Evaluation()
@@ -64,9 +64,9 @@ def case_one_source_two_commands():
 
 
 def case_one_source_three_commands():
-    command1 = command_mock(COMMAND1, return_code=0)
-    command2 = command_mock(COMMAND2, return_code=1)
-    command3 = command_mock(COMMAND3, return_code=5)
+    command1 = command_mock(COMMAND1)
+    command2 = command_mock(COMMAND2, success=False)
+    command3 = command_mock(COMMAND3, success=False)
     commands_map = {SOURCE1: [command1, command2, command3]}
 
     evaluation = Evaluation()
@@ -94,8 +94,8 @@ def case_one_source_three_commands():
 
 
 def case_two_sources_two_commands():
-    command1 = command_mock(COMMAND1, return_code=0)
-    command2 = command_mock(COMMAND2, return_code=1)
+    command1 = command_mock(COMMAND1)
+    command2 = command_mock(COMMAND2, success=False)
     commands_map = {SOURCE1: [command1], SOURCE2: [command2]}
 
     evaluation = Evaluation()

--- a/tests/evaluation/test_evaluate_commands_map.py
+++ b/tests/evaluation/test_evaluate_commands_map.py
@@ -2,12 +2,8 @@ from unittest.mock import Mock, call
 
 from pytest_cases import THIS_MODULE, parametrize_with_cases
 
-from statue.evaluation import (
-    CommandEvaluation,
-    Evaluation,
-    SourceEvaluation,
-    evaluate_commands_map,
-)
+from statue.evaluation import CommandEvaluation, Evaluation, SourceEvaluation
+from statue.runner import evaluate_commands_map
 from statue.verbosity import SILENT
 from tests.constants import COMMAND1, COMMAND2, COMMAND3, SOURCE1, SOURCE2
 from tests.util import assert_calls, command_mock

--- a/tests/util.py
+++ b/tests/util.py
@@ -8,7 +8,7 @@ def build_contexts_map(*contexts):
 
 
 def command_mock(
-    name, installed=True, return_code=None, version=None, installed_version="0.0.1"
+    name, installed=True, version=None, success=True, installed_version="0.0.1"
 ):
     command = Command(name=name, help="This is help", version=version)
     command.name = name
@@ -21,11 +21,8 @@ def command_mock(
     else:
         get_package.return_value.version = installed_version
     command._get_package = get_package  # pylint: disable=protected-access
-    if return_code is not None:
-        command_evaluation = CommandEvaluation(
-            command=command, success=return_code == 0
-        )
-        command.execute = mock.Mock(return_value=command_evaluation)
+    command_evaluation = CommandEvaluation(command=command, success=success)
+    command.execute = mock.Mock(return_value=command_evaluation)
     return command
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from statue.command import Command
+from statue.command import Command, CommandEvaluation
 
 
 def build_contexts_map(*contexts):
@@ -22,7 +22,10 @@ def command_mock(
         get_package.return_value.version = installed_version
     command._get_package = get_package  # pylint: disable=protected-access
     if return_code is not None:
-        command.execute = mock.Mock(return_value=return_code)
+        command_evaluation = CommandEvaluation(
+            command=command, success=return_code == 0
+        )
+        command.execute = mock.Mock(return_value=command_evaluation)
     return command
 
 


### PR DESCRIPTION
Changed so `Command.execute()` returns `CommandEvaluation` instead of an exit code.