### PR TITLE
Update test_requirements.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,12 +35,11 @@ include_package_data = True
 package_dir =
     = src
 install_requires =
-    toml >= 0.10.1
-    click >= 7.1.2
-    dataclasses >= 0.7; python_version == "3.6"
-    GitPython >= 3.1.9
-    types-toml >= 0.10.1
-    types-setuptools >= 57.4.4
+    toml >= 0.10.2
+    click >= 8.0.1
+    GitPython >= 3.1.26
+    types-toml >= 0.10.3
+    types-setuptools >= 57.4.8
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,8 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development
     Topic :: Utilities
@@ -28,7 +30,7 @@ platforms = any
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     = src

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 6.0.1
-pytest-mock >= 3.2.0
-pytest-cases >= 2.1.2
-coverage >= 5.2.1
+pytest >= 6.2.5, < 7.0.0
+pytest-mock >= 3.7.0
+pytest-cases >= 3.6.8
+coverage >= 6.3.1


### PR DESCRIPTION
**Description**
Update libraries and drop python 3.6 support.

At the moment we cannot use *Pytest* version 7.0.0 because it is not compatible with *Pytest-Cases*. Once it will be fixed, we will change that

**Tests**
Ran all unit tests.

**Alternatives**
Not relevant

**Additional context**
Python 3.8, Windows