### PR TITLE
Config show tree

### DIFF
--- a/src/statue/cli/history.py
+++ b/src/statue/cli/history.py
@@ -7,7 +7,7 @@ import click
 
 from statue.cache import Cache
 from statue.cli.cli import statue_cli
-from statue.cli.util import bullet_style, failure_style, success_style
+from statue.cli.util import bullet_style, failure_style, source_style, success_style
 from statue.command import CommandEvaluation
 from statue.constants import DATETIME_FORMAT
 from statue.evaluation import Evaluation
@@ -115,7 +115,7 @@ def show_evaluation_cli(number):
         f"({evaluation_success_ratio(evaluation)} successful)"
     )
     for source, source_evaluation in evaluation.items():
-        click.echo(f"{source}:")
+        click.echo(f"{source_style(source)}:")
         for command_evaluation in source_evaluation.commands_evaluations:
             click.echo(
                 f"\t{command_evaluation.command.name} - "

--- a/src/statue/cli/run.py
+++ b/src/statue/cli/run.py
@@ -19,6 +19,7 @@ from statue.cli.util import (
     verbosity_option,
 )
 from statue.commands_map import read_commands_map
+from statue.configuration import Configuration
 from statue.evaluation import Evaluation
 from statue.exceptions import MissingConfiguration, UnknownContext
 from statue.runner import evaluate_commands_map
@@ -96,6 +97,7 @@ def run_cli(  # pylint: disable=too-many-arguments
     which files to run
     """
     commands_map = None
+    sources = sources if len(sources) != 0 else Configuration.sources_list()
     try:
         commands_map = __get_commands_map(
             sources=sources,

--- a/src/statue/cli/run.py
+++ b/src/statue/cli/run.py
@@ -2,7 +2,7 @@
 """Run CLI."""
 from itertools import chain
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union
 
 import click
 
@@ -13,7 +13,9 @@ from statue.cli.util import (
     contexts_option,
     deny_option,
     failure_style,
+    name_style,
     silent_option,
+    source_style,
     success_style,
     verbose_option,
     verbosity_option,
@@ -78,7 +80,7 @@ from statue.verbosity import is_silent
 )
 def run_cli(  # pylint: disable=too-many-arguments
     ctx: click.Context,
-    sources: List[Union[Path, str]],
+    sources: Sequence[Union[Path, str]],
     context: Optional[List[str]],
     allow: Optional[List[str]],
     deny: Optional[List[str]],
@@ -97,7 +99,8 @@ def run_cli(  # pylint: disable=too-many-arguments
     which files to run
     """
     commands_map = None
-    sources = sources if len(sources) != 0 else Configuration.sources_list()
+    if len(sources) == 0:
+        sources = Configuration.sources_list()
     try:
         commands_map = __get_commands_map(
             sources=sources,
@@ -174,10 +177,10 @@ def __evaluate_failure_evaluation(failure_evaluation: Evaluation):
     click.echo("Statue has failed on the following commands:")
     click.echo()
     for source, source_evaluation in failure_evaluation.items():
-        click.echo(f"{source}:")
+        click.echo(f"{source_style(source)}:")
         failed_commands_string = ", ".join(
             [
-                command_evaluation.command.name
+                name_style(command_evaluation.command.name)
                 for command_evaluation in source_evaluation
             ]
         )

--- a/src/statue/cli/util.py
+++ b/src/statue/cli/util.py
@@ -33,6 +33,17 @@ verbose_option = click.option(
 )
 
 
+def source_style(source):
+    """
+    Styling function to emphasise sources paths.
+
+    :param source: The source name to style
+    :return: Styles source
+    :rtype: str
+    """
+    return click.style(source, fg="cyan")
+
+
 def name_style(name):
     """
     Styling function to emphasise names.

--- a/src/statue/commands_map.py
+++ b/src/statue/commands_map.py
@@ -40,8 +40,6 @@ def read_commands_map(
     :return: Dictionary from source file to the commands to run on it.
     :rtype: None or commands dictionary
     """
-    if len(sources) == 0:
-        sources = Configuration.sources_list()
     commands_map = CommandsMap()
     for source in sources:
         instructions = None

--- a/tests/cli/config/test_config_show_tree.py
+++ b/tests/cli/config/test_config_show_tree.py
@@ -1,0 +1,100 @@
+from pytest_cases import THIS_MODULE, parametrize_with_cases
+
+from statue.cli import statue_cli
+from statue.constants import ALLOW_LIST, CONTEXTS, DENY_LIST
+from tests.constants import (
+    COMMAND1,
+    COMMAND2,
+    COMMAND3,
+    CONTEXT1,
+    CONTEXT2,
+    SOURCE1,
+    SOURCE2,
+)
+from tests.util import command_mock
+
+
+def case_no_sources():
+    sources_config = {}
+    commands_lists = []
+    printed_tree = "No sources configuration is specified.\n"
+    return sources_config, commands_lists, printed_tree
+
+
+def case_one_source_empty_configuration():
+    sources_config = {SOURCE1: {}}
+    commands_lists = [[command_mock(name=COMMAND1)]]
+    printed_tree = (
+        f"{SOURCE1} (contexts: empty, allowed: empty, denied: empty):\n"
+        f"\t{COMMAND1}\n"
+    )
+    return sources_config, commands_lists, printed_tree
+
+
+def case_one_source_with_configuration():
+    sources_config = {
+        SOURCE1: {CONTEXTS: [CONTEXT1], ALLOW_LIST: [COMMAND1], DENY_LIST: []}
+    }
+    commands_lists = [[command_mock(name=COMMAND1)]]
+    printed_tree = (
+        f"{SOURCE1} (contexts: {CONTEXT1}, allowed: {COMMAND1}, denied: empty):\n"
+        f"\t{COMMAND1}\n"
+    )
+    return sources_config, commands_lists, printed_tree
+
+
+def case_one_source_with_multiple_contexts():
+    sources_config = {
+        SOURCE1: {CONTEXTS: [CONTEXT1, CONTEXT2], ALLOW_LIST: [COMMAND1], DENY_LIST: []}
+    }
+    commands_lists = [[command_mock(name=COMMAND1)]]
+    printed_tree = (
+        f"{SOURCE1} (contexts: {CONTEXT1}, {CONTEXT2}, "
+        f"allowed: {COMMAND1}, denied: empty):\n"
+        f"\t{COMMAND1}\n"
+    )
+    return sources_config, commands_lists, printed_tree
+
+
+def case_multiple_sources():
+    sources_config = {
+        SOURCE1: {
+            CONTEXTS: [CONTEXT1, CONTEXT2],
+            ALLOW_LIST: [COMMAND1],
+            DENY_LIST: [],
+        },
+        SOURCE2: {CONTEXTS: [], ALLOW_LIST: [COMMAND2, COMMAND3], DENY_LIST: []},
+    }
+    commands_lists = [
+        [command_mock(name=COMMAND1)],
+        [command_mock(name=COMMAND2), command_mock(name=COMMAND3)],
+    ]
+    printed_tree = (
+        f"{SOURCE1} (contexts: {CONTEXT1}, {CONTEXT2}, "
+        f"allowed: {COMMAND1}, denied: empty):\n"
+        f"\t{COMMAND1}\n"
+        f"{SOURCE2} (contexts: empty, "
+        f"allowed: {COMMAND2}, {COMMAND3}, denied: empty):\n"
+        f"\t{COMMAND2}, {COMMAND3}\n"
+    )
+    return sources_config, commands_lists, printed_tree
+
+
+@parametrize_with_cases(
+    argnames=["sources_config", "commands_lists", "printed_tree"], cases=THIS_MODULE
+)
+def test_config_show_tree(
+    sources_config,
+    commands_lists,
+    printed_tree,
+    cli_runner,
+    mock_sources_configuration,
+    mock_read_commands,
+):
+    mock_sources_configuration.return_value = sources_config
+    mock_read_commands.side_effect = commands_lists
+    result = cli_runner.invoke(statue_cli, ["config", "show-tree"])
+    assert (
+        result.exit_code == 0
+    ), f"Exited with error code. exception: {result.exception}"
+    assert result.output == printed_tree

--- a/tests/cli/test_run_cli.py
+++ b/tests/cli/test_run_cli.py
@@ -67,6 +67,7 @@ def assert_usage_was_shown(result):
 
 def test_simple_run(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,
@@ -84,6 +85,7 @@ def test_simple_run(
 
 def test_run_with_no_cache(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,
@@ -101,6 +103,7 @@ def test_run_with_no_cache(
 
 def test_run_and_install_uninstalled_commands(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,
@@ -130,6 +133,7 @@ def test_run_and_install_uninstalled_commands(
 
 def test_run_and_save_to_file(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,
@@ -151,6 +155,7 @@ def test_run_and_save_to_file(
 
 def test_run_over_recent_commands(
     cli_runner,
+    mock_sources_list,
     mock_cache_evaluation_path,
     mock_evaluation_load_from_file,
     mock_cache_save_evaluation,
@@ -173,6 +178,7 @@ def test_run_over_recent_commands(
 
 def test_run_over_failed_commands(
     cli_runner,
+    mock_sources_list,
     mock_cache_evaluation_path,
     mock_cache_save_evaluation,
     mock_evaluation_load_from_file,
@@ -197,6 +203,7 @@ def test_run_over_failed_commands(
 
 def test_run_over_previous_commands(
     cli_runner,
+    mock_sources_list,
     mock_cache_evaluation_path,
     mock_cache_save_evaluation,
     mock_evaluation_load_from_file,
@@ -220,6 +227,7 @@ def test_run_over_previous_commands(
 
 def test_run_over_previous_failed_commands(
     cli_runner,
+    mock_sources_list,
     mock_cache_evaluation_path,
     mock_cache_save_evaluation,
     mock_evaluation_load_from_file,
@@ -245,6 +253,7 @@ def test_run_over_previous_failed_commands(
 
 def test_run_over_recent_commands_with_empty_cache(
     cli_runner,
+    mock_sources_list,
     mock_cache_evaluation_path,
     mock_cwd,
     mock_evaluation_string,
@@ -260,6 +269,7 @@ def test_run_over_recent_commands_with_empty_cache(
 
 def test_run_has_failed(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,
@@ -306,6 +316,7 @@ def test_run_has_failed(
 
 def test_run_with_unknown_context(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,
@@ -325,6 +336,7 @@ def test_run_with_unknown_context(
 
 def test_run_with_missing_configuration(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,
@@ -347,6 +359,7 @@ def test_run_with_missing_configuration(
 
 def test_run_with_none_commands_map(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,
@@ -362,6 +375,7 @@ def test_run_with_none_commands_map(
 
 def test_run_uninstalled_command(
     cli_runner,
+    mock_sources_list,
     mock_read_commands_map,
     mock_cache_save_evaluation,
     mock_cwd,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,11 @@ def mock_commands_names_list(mocker, clear_configuration):
 
 
 @pytest.fixture
+def mock_sources_list(mocker):
+    return mocker.patch.object(Configuration, "sources_list")
+
+
+@pytest.fixture
 def mock_default_configuration(mocker, clear_configuration):
     return mocker.patch.object(Configuration, "default_configuration")
 


### PR DESCRIPTION
**Description**
Added a command to show source configuration as tree, including:

* Contexts
* Allow list
* Deny list
* matching commands

**Tests**
Added unit tests and ran the command on multiple repositories

**Alternatives**
Not relevant

**Additional context**
python 3.8, windows