### PR TITLE
Add duration to command evaluation

### DIFF
--- a/src/statue/command.py
+++ b/src/statue/command.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import subprocess  # nosec
 import sys
+import time
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -20,6 +21,7 @@ class CommandEvaluation:
 
     command: "Command"
     success: bool
+    execution_duration: float
     captured_output: List[str] = field(default_factory=list)
 
     @property
@@ -41,6 +43,7 @@ class CommandEvaluation:
         }
         return dict(
             command=command_json,
+            execution_duration=self.execution_duration,
             captured_output=self.captured_output,
             success=self.success,
         )
@@ -58,6 +61,7 @@ class CommandEvaluation:
         return CommandEvaluation(
             command=Command(**command_evaluation["command"]),
             success=command_evaluation["success"],
+            execution_duration=command_evaluation["execution_duration"],
             captured_output=command_evaluation["captured_output"],
         )
 
@@ -225,10 +229,13 @@ class Command:
         :return: Command's evaluation including the command itself and is it successful
         :rtype: CommandEvaluation
         """
+        start_time = time.time()
         subprocess_result = self._run_subprocess(args=[self.name, source, *self.args])
+        end_time = time.time()
         return CommandEvaluation(
             command=self,
             success=(subprocess_result.returncode == 0),
+            execution_duration=end_time - start_time,
             captured_output=self._build_captured_output(subprocess_result),
         )
 

--- a/src/statue/string_util.py
+++ b/src/statue/string_util.py
@@ -65,6 +65,8 @@ def evaluation_string(
                     f"{command_evaluation.command.name} "
                     "ran with args: "
                     f"{command_evaluation.command.args}\n"
+                    f"Finished in {command_evaluation.execution_duration:.2f} "
+                    "seconds.\n"
                 )
             returned += f"{command_evaluation.captured_output_string}\n"
     return returned

--- a/tests/cli/test_history_cli.py
+++ b/tests/cli/test_history_cli.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 import re
 from unittest import mock
 
@@ -21,15 +22,35 @@ EVALUATION = Evaluation(
     {
         SOURCE1: SourceEvaluation(
             [
-                CommandEvaluation(command=command_mock(name=COMMAND1), success=True),
-                CommandEvaluation(command=command_mock(name=COMMAND2), success=False),
-                CommandEvaluation(command=command_mock(name=COMMAND3), success=True),
+                CommandEvaluation(
+                    command=command_mock(name=COMMAND1),
+                    execution_duration=random.random(),
+                    success=True,
+                ),
+                CommandEvaluation(
+                    command=command_mock(name=COMMAND2),
+                    execution_duration=random.random(),
+                    success=False,
+                ),
+                CommandEvaluation(
+                    command=command_mock(name=COMMAND3),
+                    execution_duration=random.random(),
+                    success=True,
+                ),
             ]
         ),
         SOURCE2: SourceEvaluation(
             [
-                CommandEvaluation(command=command_mock(name=COMMAND4), success=True),
-                CommandEvaluation(command=command_mock(name=COMMAND5), success=False),
+                CommandEvaluation(
+                    command=command_mock(name=COMMAND4),
+                    execution_duration=random.random(),
+                    success=True,
+                ),
+                CommandEvaluation(
+                    command=command_mock(name=COMMAND5),
+                    execution_duration=random.random(),
+                    success=False,
+                ),
             ]
         ),
     }

--- a/tests/evaluation/test_evaluate_commands_map.py
+++ b/tests/evaluation/test_evaluate_commands_map.py
@@ -1,4 +1,5 @@
 import itertools
+import random
 from unittest import mock
 
 from pytest_cases import THIS_MODULE, parametrize_with_cases
@@ -25,14 +26,22 @@ def case_empty_commands_map():
 
 
 def case_one_source_one_command():
-    command1 = command_mock(COMMAND1, captured_output=COMMAND_CAPTURED_OUTPUT1)
+    execution_duration = random.random()
+    command1 = command_mock(
+        COMMAND1,
+        execution_duration=execution_duration,
+        captured_output=COMMAND_CAPTURED_OUTPUT1,
+    )
     commands_map = {SOURCE1: [command1]}
 
     evaluation = Evaluation()
     evaluation[SOURCE1] = SourceEvaluation(
         [
             CommandEvaluation(
-                command=command1, success=True, captured_output=COMMAND_CAPTURED_OUTPUT1
+                command=command1,
+                execution_duration=execution_duration,
+                success=True,
+                captured_output=COMMAND_CAPTURED_OUTPUT1,
             )
         ]
     )
@@ -40,9 +49,17 @@ def case_one_source_one_command():
 
 
 def case_one_source_two_commands():
-    command1 = command_mock(COMMAND1, captured_output=COMMAND_CAPTURED_OUTPUT1)
+    execution_duration1, execution_duration2 = random.random(), random.random()
+    command1 = command_mock(
+        COMMAND1,
+        execution_duration=execution_duration1,
+        captured_output=COMMAND_CAPTURED_OUTPUT1,
+    )
     command2 = command_mock(
-        COMMAND2, success=False, captured_output=COMMAND_CAPTURED_OUTPUT2
+        COMMAND2,
+        execution_duration=execution_duration2,
+        success=False,
+        captured_output=COMMAND_CAPTURED_OUTPUT2,
     )
     commands_map = {SOURCE1: [command1, command2]}
 
@@ -50,10 +67,14 @@ def case_one_source_two_commands():
     evaluation[SOURCE1] = SourceEvaluation(
         [
             CommandEvaluation(
-                command=command1, success=True, captured_output=COMMAND_CAPTURED_OUTPUT1
+                command=command1,
+                execution_duration=execution_duration1,
+                success=True,
+                captured_output=COMMAND_CAPTURED_OUTPUT1,
             ),
             CommandEvaluation(
                 command=command2,
+                execution_duration=execution_duration2,
                 success=False,
                 captured_output=COMMAND_CAPTURED_OUTPUT2,
             ),
@@ -64,12 +85,27 @@ def case_one_source_two_commands():
 
 
 def case_one_source_three_commands():
-    command1 = command_mock(COMMAND1, captured_output=COMMAND_CAPTURED_OUTPUT1)
+    execution_duration1, execution_duration2, execution_duration3 = (
+        random.random(),
+        random.random(),
+        random.random(),
+    )
+    command1 = command_mock(
+        COMMAND1,
+        execution_duration=execution_duration1,
+        captured_output=COMMAND_CAPTURED_OUTPUT1,
+    )
     command2 = command_mock(
-        COMMAND2, success=False, captured_output=COMMAND_CAPTURED_OUTPUT2
+        COMMAND2,
+        execution_duration=execution_duration2,
+        success=False,
+        captured_output=COMMAND_CAPTURED_OUTPUT2,
     )
     command3 = command_mock(
-        COMMAND3, success=False, captured_output=COMMAND_CAPTURED_OUTPUT3
+        COMMAND3,
+        execution_duration=execution_duration3,
+        success=False,
+        captured_output=COMMAND_CAPTURED_OUTPUT3,
     )
     commands_map = {SOURCE1: [command1, command2, command3]}
 
@@ -77,15 +113,20 @@ def case_one_source_three_commands():
     evaluation[SOURCE1] = SourceEvaluation(
         [
             CommandEvaluation(
-                command=command1, success=True, captured_output=COMMAND_CAPTURED_OUTPUT1
+                command=command1,
+                execution_duration=execution_duration1,
+                success=True,
+                captured_output=COMMAND_CAPTURED_OUTPUT1,
             ),
             CommandEvaluation(
                 command=command2,
                 success=False,
+                execution_duration=execution_duration2,
                 captured_output=COMMAND_CAPTURED_OUTPUT2,
             ),
             CommandEvaluation(
                 command=command3,
+                execution_duration=execution_duration3,
                 success=False,
                 captured_output=COMMAND_CAPTURED_OUTPUT3,
             ),
@@ -95,9 +136,17 @@ def case_one_source_three_commands():
 
 
 def case_two_sources_two_commands():
-    command1 = command_mock(COMMAND1, captured_output=COMMAND_CAPTURED_OUTPUT1)
+    execution_duration1, execution_duration2 = random.random(), random.random()
+    command1 = command_mock(
+        COMMAND1,
+        execution_duration=execution_duration1,
+        captured_output=COMMAND_CAPTURED_OUTPUT1,
+    )
     command2 = command_mock(
-        COMMAND2, success=False, captured_output=COMMAND_CAPTURED_OUTPUT2
+        COMMAND2,
+        execution_duration=execution_duration2,
+        success=False,
+        captured_output=COMMAND_CAPTURED_OUTPUT2,
     )
     commands_map = {SOURCE1: [command1], SOURCE2: [command2]}
 
@@ -105,7 +154,10 @@ def case_two_sources_two_commands():
     evaluation[SOURCE1] = SourceEvaluation(
         [
             CommandEvaluation(
-                command=command1, success=True, captured_output=COMMAND_CAPTURED_OUTPUT1
+                command=command1,
+                execution_duration=execution_duration1,
+                success=True,
+                captured_output=COMMAND_CAPTURED_OUTPUT1,
             )
         ]
     )
@@ -113,6 +165,7 @@ def case_two_sources_two_commands():
         [
             CommandEvaluation(
                 command=command2,
+                execution_duration=execution_duration2,
                 success=False,
                 captured_output=COMMAND_CAPTURED_OUTPUT2,
             )

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -1,3 +1,5 @@
+import random
+
 from pytest_cases import THIS_MODULE, case, parametrize_with_cases
 
 from statue.evaluation import CommandEvaluation, Evaluation, SourceEvaluation
@@ -13,7 +15,6 @@ from tests.constants import (
     SOURCE2,
     SUCCESSFUL_TAG,
 )
-from tests.util import build_failure_evaluation
 
 
 @case(tags=[SUCCESSFUL_TAG])
@@ -30,15 +31,35 @@ def case_all_successful():
         {
             SOURCE1: SourceEvaluation(
                 [
-                    CommandEvaluation(command=COMMAND1, success=True),
-                    CommandEvaluation(command=COMMAND2, success=True),
+                    CommandEvaluation(
+                        command=COMMAND1,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND2,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
                 ]
             ),
             SOURCE2: SourceEvaluation(
                 [
-                    CommandEvaluation(command=COMMAND3, success=True),
-                    CommandEvaluation(command=COMMAND4, success=True),
-                    CommandEvaluation(command=COMMAND5, success=True),
+                    CommandEvaluation(
+                        command=COMMAND3,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND4,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND5,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
                 ]
             ),
         }
@@ -53,24 +74,57 @@ def case_all_successful():
 
 @case(tags=[FAILED_TAG])
 def case_one_failure():
+    failed_execution_duration = random.random()
     evaluation = Evaluation(
         {
             SOURCE1: SourceEvaluation(
                 [
-                    CommandEvaluation(command=COMMAND1, success=True),
-                    CommandEvaluation(command=COMMAND2, success=False),
+                    CommandEvaluation(
+                        command=COMMAND1,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND2,
+                        execution_duration=failed_execution_duration,
+                        success=False,
+                    ),
                 ]
             ),
             SOURCE2: SourceEvaluation(
                 [
-                    CommandEvaluation(command=COMMAND3, success=True),
-                    CommandEvaluation(command=COMMAND4, success=True),
-                    CommandEvaluation(command=COMMAND5, success=True),
+                    CommandEvaluation(
+                        command=COMMAND3,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND4,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND5,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
                 ]
             ),
         }
     )
-    failure_evaluation = build_failure_evaluation({SOURCE1: [COMMAND2]})
+    failure_evaluation = Evaluation(
+        {
+            SOURCE1: SourceEvaluation(
+                [
+                    CommandEvaluation(
+                        command=COMMAND2,
+                        execution_duration=failed_execution_duration,
+                        success=False,
+                    )
+                ]
+            )
+        }
+    )
     commands_map = {
         SOURCE1: [COMMAND1, COMMAND2],
         SOURCE2: [COMMAND3, COMMAND4, COMMAND5],
@@ -80,25 +134,70 @@ def case_one_failure():
 
 @case(tags=[FAILED_TAG])
 def case_one_source_with_two_failures():
+    failed_command_duration1, failed_command_duration2 = (
+        random.random(),
+        random.random(),
+    )
     evaluation = Evaluation(
         {
             SOURCE1: SourceEvaluation(
                 [
-                    CommandEvaluation(command=COMMAND1, success=True),
-                    CommandEvaluation(command=COMMAND2, success=True),
-                    CommandEvaluation(command=COMMAND3, success=True),
+                    CommandEvaluation(
+                        command=COMMAND1,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND2,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND3,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
                 ]
             ),
             SOURCE2: SourceEvaluation(
                 [
-                    CommandEvaluation(command=COMMAND4, success=False),
-                    CommandEvaluation(command=COMMAND5, success=True),
-                    CommandEvaluation(command=COMMAND6, success=False),
+                    CommandEvaluation(
+                        command=COMMAND4,
+                        execution_duration=failed_command_duration1,
+                        success=False,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND5,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND6,
+                        execution_duration=failed_command_duration2,
+                        success=False,
+                    ),
                 ]
             ),
         }
     )
-    failure_evaluation = build_failure_evaluation({SOURCE2: [COMMAND4, COMMAND6]})
+    failure_evaluation = Evaluation(
+        {
+            SOURCE2: SourceEvaluation(
+                [
+                    CommandEvaluation(
+                        command=COMMAND4,
+                        execution_duration=failed_command_duration1,
+                        success=False,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND6,
+                        execution_duration=failed_command_duration2,
+                        success=False,
+                    ),
+                ]
+            )
+        }
+    )
     commands_map = {
         SOURCE1: [COMMAND1, COMMAND2, COMMAND3],
         SOURCE2: [COMMAND4, COMMAND5, COMMAND6],
@@ -108,28 +207,78 @@ def case_one_source_with_two_failures():
 
 @case(tags=[FAILED_TAG])
 def case_two_sources_with_failures():
+    failed_command_duration1, failed_command_duration2, failed_command_duration3 = (
+        random.random(),
+        random.random(),
+        random.random(),
+    )
     evaluation = Evaluation(
         {
             SOURCE1: SourceEvaluation(
                 [
-                    CommandEvaluation(command=COMMAND1, success=False),
-                    CommandEvaluation(command=COMMAND2, success=True),
-                    CommandEvaluation(command=COMMAND3, success=False),
+                    CommandEvaluation(
+                        command=COMMAND1,
+                        execution_duration=failed_command_duration1,
+                        success=False,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND2,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND3,
+                        execution_duration=failed_command_duration2,
+                        success=False,
+                    ),
                 ]
             ),
             SOURCE2: SourceEvaluation(
                 [
-                    CommandEvaluation(command=COMMAND4, success=True),
-                    CommandEvaluation(command=COMMAND5, success=False),
-                    CommandEvaluation(command=COMMAND6, success=True),
+                    CommandEvaluation(
+                        command=COMMAND4,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND5,
+                        execution_duration=failed_command_duration3,
+                        success=False,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND6,
+                        execution_duration=random.random(),
+                        success=True,
+                    ),
                 ]
             ),
         }
     )
-    failure_evaluation = build_failure_evaluation(
+    failure_evaluation = Evaluation(
         {
-            SOURCE1: [COMMAND1, COMMAND3],
-            SOURCE2: [COMMAND5],
+            SOURCE1: SourceEvaluation(
+                [
+                    CommandEvaluation(
+                        command=COMMAND1,
+                        execution_duration=failed_command_duration1,
+                        success=False,
+                    ),
+                    CommandEvaluation(
+                        command=COMMAND3,
+                        execution_duration=failed_command_duration2,
+                        success=False,
+                    ),
+                ]
+            ),
+            SOURCE2: SourceEvaluation(
+                [
+                    CommandEvaluation(
+                        command=COMMAND5,
+                        execution_duration=failed_command_duration3,
+                        success=False,
+                    )
+                ]
+            ),
         }
     )
     commands_map = {

--- a/tests/evaluation/test_read_write_evaluation.py
+++ b/tests/evaluation/test_read_write_evaluation.py
@@ -1,3 +1,4 @@
+import random
 from pathlib import Path
 from unittest import mock
 
@@ -33,12 +34,14 @@ def case_one_source_no_commands():
 
 
 def case_one_source_one_commands():
+    execution_duration = random.random()
     evaluation_json = {
         SOURCE1: dict(
             commands_evaluations=[
                 dict(
                     command=dict(name=COMMAND1, help=COMMAND_HELP_STRING1, args=[]),
                     captured_output=COMMAND_CAPTURED_OUTPUT1,
+                    execution_duration=execution_duration,
                     success=True,
                 )
             ]
@@ -50,6 +53,7 @@ def case_one_source_one_commands():
             CommandEvaluation(
                 command=Command(COMMAND1, help=COMMAND_HELP_STRING1),
                 captured_output=COMMAND_CAPTURED_OUTPUT1,
+                execution_duration=execution_duration,
                 success=True,
             )
         ]
@@ -58,12 +62,14 @@ def case_one_source_one_commands():
 
 
 def case_one_source_two_commands():
+    execution_duration1, execution_duration2 = random.random(), random.random()
     evaluation_json = {
         SOURCE1: dict(
             commands_evaluations=[
                 dict(
                     command=dict(name=COMMAND1, help=COMMAND_HELP_STRING1, args=[]),
                     captured_output=COMMAND_CAPTURED_OUTPUT1,
+                    execution_duration=execution_duration1,
                     success=True,
                 ),
                 dict(
@@ -71,6 +77,7 @@ def case_one_source_two_commands():
                         name=COMMAND2, help=COMMAND_HELP_STRING2, args=[ARG1, ARG2]
                     ),
                     captured_output=COMMAND_CAPTURED_OUTPUT2,
+                    execution_duration=execution_duration2,
                     success=False,
                 ),
             ]
@@ -82,11 +89,13 @@ def case_one_source_two_commands():
             CommandEvaluation(
                 command=Command(COMMAND1, help=COMMAND_HELP_STRING1),
                 captured_output=COMMAND_CAPTURED_OUTPUT1,
+                execution_duration=execution_duration1,
                 success=True,
             ),
             CommandEvaluation(
                 command=Command(COMMAND2, help=COMMAND_HELP_STRING2, args=[ARG1, ARG2]),
                 captured_output=COMMAND_CAPTURED_OUTPUT2,
+                execution_duration=execution_duration2,
                 success=False,
             ),
         ]
@@ -95,12 +104,14 @@ def case_one_source_two_commands():
 
 
 def case_two_sources_two_commands():
+    execution_duration1, execution_duration2 = random.random(), random.random()
     evaluation_json = {
         SOURCE1: dict(
             commands_evaluations=[
                 dict(
                     command=dict(name=COMMAND1, help=COMMAND_HELP_STRING1, args=[]),
                     captured_output=COMMAND_CAPTURED_OUTPUT1,
+                    execution_duration=execution_duration1,
                     success=True,
                 )
             ]
@@ -112,6 +123,7 @@ def case_two_sources_two_commands():
                         name=COMMAND2, help=COMMAND_HELP_STRING2, args=[ARG1, ARG2]
                     ),
                     captured_output=COMMAND_CAPTURED_OUTPUT2,
+                    execution_duration=execution_duration2,
                     success=False,
                 )
             ]
@@ -123,6 +135,7 @@ def case_two_sources_two_commands():
             CommandEvaluation(
                 command=Command(COMMAND1, help=COMMAND_HELP_STRING1),
                 captured_output=COMMAND_CAPTURED_OUTPUT1,
+                execution_duration=execution_duration1,
                 success=True,
             ),
         ]
@@ -132,6 +145,7 @@ def case_two_sources_two_commands():
             CommandEvaluation(
                 command=Command(COMMAND2, help=COMMAND_HELP_STRING2, args=[ARG1, ARG2]),
                 captured_output=COMMAND_CAPTURED_OUTPUT2,
+                execution_duration=execution_duration2,
                 success=False,
             ),
         ]

--- a/tests/string_utils/test_evaluation_string.py
+++ b/tests/string_utils/test_evaluation_string.py
@@ -1,3 +1,5 @@
+import random
+
 from pytest_cases import THIS_MODULE, parametrize_with_cases
 
 from statue.command import CommandEvaluation
@@ -29,6 +31,7 @@ def case_one_source_one_command():
                 [
                     CommandEvaluation(
                         command=command_mock(COMMAND1),
+                        execution_duration=random.random(),
                         success=True,
                         captured_output=COMMAND_CAPTURED_OUTPUT1,
                     )
@@ -57,11 +60,13 @@ def case_one_source_two_commands():
                 [
                     CommandEvaluation(
                         command=command_mock(COMMAND1),
+                        execution_duration=random.random(),
                         success=True,
                         captured_output=COMMAND_CAPTURED_OUTPUT1,
                     ),
                     CommandEvaluation(
                         command=command_mock(COMMAND2),
+                        execution_duration=random.random(),
                         success=True,
                         captured_output=COMMAND_CAPTURED_OUTPUT2,
                     ),
@@ -94,6 +99,7 @@ def case_two_sources_two_commands():
                 [
                     CommandEvaluation(
                         command=command_mock(COMMAND1),
+                        execution_duration=random.random(),
                         success=True,
                         captured_output=COMMAND_CAPTURED_OUTPUT1,
                     )
@@ -103,6 +109,7 @@ def case_two_sources_two_commands():
                 [
                     CommandEvaluation(
                         command=command_mock(COMMAND2),
+                        execution_duration=random.random(),
                         success=True,
                         captured_output=COMMAND_CAPTURED_OUTPUT2,
                     )
@@ -130,12 +137,14 @@ def case_two_sources_two_commands():
 
 
 def case_evaluation_string_verbose():
+    execution_duration = 0.25
     evaluation = Evaluation(
         {
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
                         command=command_mock(COMMAND1, args=["a", "b", "c"]),
+                        execution_duration=execution_duration,
                         success=True,
                         captured_output=COMMAND_CAPTURED_OUTPUT1,
                     )
@@ -153,6 +162,7 @@ def case_evaluation_string_verbose():
         "command1\n"
         "--------\n"
         "command1 ran with args: ['a', 'b', 'c']\n"
+        "Finished in 0.25 seconds.\n"
         f"{joined_command_output}\n"
     )
     return evaluation, kwargs, result

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,4 @@
+import random
 from unittest import mock
 
 from statue.command import Command, CommandEvaluation
@@ -13,7 +14,11 @@ def build_failure_evaluation(commands_map):
         {
             source: SourceEvaluation(
                 [
-                    CommandEvaluation(command=command, success=False)
+                    CommandEvaluation(
+                        command=command,
+                        execution_duration=random.random(),
+                        success=False,
+                    )
                     for command in commands
                 ]
             )
@@ -26,6 +31,7 @@ def command_mock(
     name,
     installed=True,
     version=None,
+    execution_duration=0,
     success=True,
     args=None,
     captured_output="",
@@ -46,6 +52,7 @@ def command_mock(
     command_evaluation = CommandEvaluation(
         command=command,
         success=success,
+        execution_duration=execution_duration,
         captured_output=captured_output,
     )
     command.execute = mock.Mock(return_value=command_evaluation)


### PR DESCRIPTION
**Description**
Save the duration of a command's execution as part of the evaluation.

**Tests**
Fixed failing unit tests and included execution time in those tests

**Alternatives**
Do not inform how long a command took to run.

**Additional context**
Python 3.9, Windows