### PR TITLE
No context by default

### DIFF
--- a/src/statue/cli/config.py
+++ b/src/statue/cli/config.py
@@ -222,8 +222,11 @@ def __update_sources_map(sources_map, sources, repo=None, interactive=False):
                 default=default_contexts_string,
                 show_default=False,
             )
-            contexts = re.split(r"[ \t]*,[ \t]*", contexts_string)
-        sources_map[source.as_posix()] = {CONTEXTS: contexts}
+            if len(contexts_string) != 0:
+                contexts = re.split(r"[ \t]*,[ \t]*", contexts_string)
+        sources_map[source.as_posix()] = {}
+        if len(contexts) != 0:
+            sources_map[source.as_posix()][CONTEXTS] = contexts
 
 
 def __get_default_contexts(source: Path):
@@ -231,7 +234,7 @@ def __get_default_contexts(source: Path):
         return ["test"]
     if source.name == "setup.py":
         return ["fast"]
-    return ["standard"]
+    return []
 
 
 def __join_names(names_list):

--- a/statue.toml
+++ b/statue.toml
@@ -30,7 +30,6 @@ version = "1.4"
 contexts = [ "fast",]
 
 [sources."src/statue"]
-contexts = [ "standard",]
 
 [sources.tests]
 contexts = [ "test",]

--- a/tests/cli/config/test_config_init.py
+++ b/tests/cli/config/test_config_init.py
@@ -5,7 +5,7 @@ from git import InvalidGitRepositoryError
 from pytest_cases import THIS_MODULE, parametrize_with_cases
 
 from statue.cli.cli import statue_cli
-from statue.constants import CONTEXTS, SOURCES, STANDARD
+from statue.constants import CONTEXTS, SOURCES
 
 
 def case_empty_sources():
@@ -14,12 +14,12 @@ def case_empty_sources():
 
 def case_regular_sources():
     src = "src"
-    return [src], {SOURCES: {src: {CONTEXTS: [STANDARD]}}}
+    return [src], {SOURCES: {src: {}}}
 
 
 def case_internal_path():
     """Paths should always be written as posix paths, even in windows"""
-    return [Path("src", "package")], {SOURCES: {"src/package": {CONTEXTS: [STANDARD]}}}
+    return [Path("src", "package")], {SOURCES: {"src/package": {}}}
 
 
 def case_test_sources():
@@ -35,7 +35,7 @@ def case_setup_sources():
 def case_all_sources():
     return ["src", "test", "setup.py"], {
         SOURCES: {
-            "src": {CONTEXTS: [STANDARD]},
+            "src": {},
             "test": {CONTEXTS: ["test"]},
             "setup.py": {CONTEXTS: ["fast"]},
         }

--- a/tests/cli/config/test_interactive_config_init.py
+++ b/tests/cli/config/test_interactive_config_init.py
@@ -3,7 +3,7 @@ from unittest import mock
 from pytest_cases import THIS_MODULE, parametrize_with_cases
 
 from statue.cli.cli import statue_cli
-from statue.constants import CONTEXTS, SOURCES, STANDARD
+from statue.constants import CONTEXTS, SOURCES
 
 
 def mock_path(posix_path, is_dir=False):

--- a/tests/cli/config/test_interactive_config_init.py
+++ b/tests/cli/config/test_interactive_config_init.py
@@ -20,13 +20,13 @@ def case_empty_sources():
 def case_one_source_with_default_yes():
     src_path = "src"
     src = mock_path(src_path)
-    return [src], ["", ""], {SOURCES: {src_path: {CONTEXTS: [STANDARD]}}}
+    return [src], ["", ""], {SOURCES: {src_path: {}}}
 
 
 def case_one_source_with_yes():
     src_path = "src"
     src = mock_path(src_path)
-    return [src], ["y", ""], {SOURCES: {src_path: {CONTEXTS: [STANDARD]}}}
+    return [src], ["y", ""], {SOURCES: {src_path: {}}}
 
 
 def case_one_source_with_no():
@@ -52,11 +52,7 @@ def case_expend_with_all_yes(mock_expend, mock_git_repo):
     one, two, three = "src/one", "src/two", "src/three"
     mock_expend.return_value = [mock_path(path) for path in [one, two, three]]
     yield [src], ["e", "y", "", "y", "", "y", ""], {
-        SOURCES: {
-            one: {CONTEXTS: [STANDARD]},
-            two: {CONTEXTS: [STANDARD]},
-            three: {CONTEXTS: [STANDARD]},
-        }
+        SOURCES: {one: {}, two: {}, three: {}}
     }
     mock_expend.assert_called_once_with(src, repo=mock_git_repo.return_value)
 
@@ -66,9 +62,7 @@ def case_expend_with_one_no(mock_expend, mock_git_repo):
     src = mock_path(src_path, is_dir=True)
     one, two, three = "src/one", "src/two", "src/three"
     mock_expend.return_value = [mock_path(path) for path in [one, two, three]]
-    yield [src], ["e", "y", "", "n", "y", ""], {
-        SOURCES: {one: {CONTEXTS: [STANDARD]}, three: {CONTEXTS: [STANDARD]}}
-    }
+    yield [src], ["e", "y", "", "n", "y", ""], {SOURCES: {one: {}, three: {}}}
     mock_expend.assert_called_once_with(src, repo=mock_git_repo.return_value)
 
 
@@ -81,7 +75,7 @@ def case_expended_get_contexts(mock_expend, mock_git_repo):
     mock_expend.return_value = [mock_path(path) for path in [one, two, three]]
     yield [src, test], ["y", "", "e", "y", "fast", "y", "", "y", "format"], {
         SOURCES: {
-            src_path: {CONTEXTS: [STANDARD]},
+            src_path: {},
             one: {CONTEXTS: ["fast"]},
             two: {CONTEXTS: ["test"]},
             three: {CONTEXTS: ["format"]},


### PR DESCRIPTION
**Description**
Related #97 

Until now, when using `statue config init`, by default the standard context was added to sources which are not test files or setup.py

The command *Autoflake* is set with `standard=False`, which means it won't be running on paths with the standard context.

However, if no context was specified, *Autoflake* is running without any problem.

Therefore, we cnahed the new default such that new sources won't have any contexts.

**Tests**
Fixed unit tests and ran `config init`.

**Alternatives**
Keep everything as it is and prevent *Autoflake* from running.

**Additional context**
Python 3.9, Windows