### PR TITLE
Add allow by default

### DIFF
--- a/src/statue/constants.py
+++ b/src/statue/constants.py
@@ -19,6 +19,7 @@ ALLOWED_CONTEXTS = "allowed_contexts"
 REQUIRED_CONTEXTS = "required_contexts"
 ALIASES = "aliases"
 PARENT = "parent"
+ALLOWED_BY_DEFAULT = "allowed_by_default"
 IS_DEFAULT = "is_default"
 VERSION = "version"
 

--- a/src/statue/context.py
+++ b/src/statue/context.py
@@ -28,11 +28,11 @@ class Context:
     aliases: List[str] = field(default_factory=list)
     parent: Optional["Context"] = field(default=None)
     is_default: bool = field(default=False)
-    _names: List[str] = field(init=False)
 
-    def __post_init__(self):
-        """Extra initialization."""
-        self._names = [self.name, *self.aliases]
+    @property
+    def all_names(self) -> List[str]:
+        """List of all possible names."""
+        return [self.name, *self.aliases]
 
     def is_allowed(self, setups: MutableMapping[str, Any]) -> bool:
         """
@@ -47,7 +47,7 @@ class Context:
             return True
         required_contexts = setups.get(REQUIRED_CONTEXTS, None)
         allowed_contexts = setups.get(ALLOWED_CONTEXTS, None)
-        for name in self._names:
+        for name in self.all_names:
             if name in setups:
                 return True
             if required_contexts is not None and name in required_contexts:
@@ -69,7 +69,7 @@ class Context:
         :return: Specific setups with context
         :rtype: None or MutableMapping[str, Any]
         """
-        for name in self._names:
+        for name in self.all_names:
             name_setups = setups.get(name, None)
             if name_setups is not None:
                 return name_setups

--- a/src/statue/context.py
+++ b/src/statue/context.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, MutableMapping, Optional
 
 from statue.constants import (
     ALIASES,
+    ALLOWED_BY_DEFAULT,
     ALLOWED_CONTEXTS,
     HELP,
     IS_DEFAULT,
@@ -121,7 +122,10 @@ class Context:
         if config is None:
             raise UnknownContext(name)
         kwargs = dict(
-            name=name, help=config[HELP], is_default=config.get(IS_DEFAULT, False)
+            name=name,
+            help=config[HELP],
+            is_default=config.get(IS_DEFAULT, False),
+            allowed_by_default=config.get(ALLOWED_BY_DEFAULT, False),
         )
         if ALIASES in config:
             kwargs[ALIASES] = config[ALIASES]

--- a/src/statue/context.py
+++ b/src/statue/context.py
@@ -27,6 +27,7 @@ class Context:
     help: str
     aliases: List[str] = field(default_factory=list)
     parent: Optional["Context"] = field(default=None)
+    allowed_by_default: bool = field(default=False)
     is_default: bool = field(default=False)
 
     @property
@@ -56,7 +57,7 @@ class Context:
                 return True
         if self.parent is not None:
             return self.parent.is_allowed(setups)
-        return False
+        return self.allowed_by_default
 
     def search_context_instructions(
         self, setups: MutableMapping[str, Any]

--- a/src/statue/resources/defaults.toml
+++ b/src/statue/resources/defaults.toml
@@ -8,7 +8,7 @@ help = "Run short-time commands. Good for smoke tests"
 
 [contexts.strict]
 help = "Strict checks, for ones who never compromise!"
-parent = "standard"
+allowed_by_default = true
 
 [contexts.test]
 help = "Checks for test files."

--- a/tests/context/test_build_context_map.py
+++ b/tests/context/test_build_context_map.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest_cases import THIS_MODULE, parametrize_with_cases
 
-from statue.constants import ALIASES, HELP, IS_DEFAULT, PARENT
+from statue.constants import ALIASES, ALLOWED_BY_DEFAULT, HELP, IS_DEFAULT, PARENT
 from statue.context import Context
 from statue.exceptions import UnknownContext
 from tests.constants import (
@@ -80,6 +80,22 @@ def case_context_inheritance_from_default():
     context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, is_default=True)
     context2 = Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2, parent=context1)
     return context_config, build_contexts_map(context1, context2)
+
+
+def case_context_allowed_by_default():
+    context_config = {CONTEXT1: {HELP: CONTEXT_HELP_STRING1, ALLOWED_BY_DEFAULT: True}}
+    context1 = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=True
+    )
+    return context_config, build_contexts_map(context1)
+
+
+def case_context_not_allowed_by_default():
+    context_config = {CONTEXT1: {HELP: CONTEXT_HELP_STRING1, ALLOWED_BY_DEFAULT: False}}
+    context1 = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=False
+    )
+    return context_config, build_contexts_map(context1)
 
 
 @parametrize_with_cases(argnames=["context_config", "contexts_map"], cases=THIS_MODULE)

--- a/tests/context/test_is_allowed.py
+++ b/tests/context/test_is_allowed.py
@@ -8,6 +8,7 @@ from tests.constants import (
     CONTEXT5,
     CONTEXT6,
     CONTEXT_HELP_STRING1,
+    CONTEXT_HELP_STRING3,
     STANDARD_HELP,
 )
 
@@ -71,10 +72,26 @@ def test_context_parent_is_allowed():
 
 def test_context_parent_alias_is_allowed():
     parent = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, aliases=[CONTEXT2])
-    context = Context(name=CONTEXT3, help=CONTEXT_HELP_STRING1, parent=parent)
+    context = Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3, parent=parent)
     setups = {ALLOWED_CONTEXTS: [CONTEXT2]}
 
     assert context.is_allowed(setups)
+
+
+def test_context_allowed_by_default():
+    context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=True)
+    setups = {}
+
+    assert context.is_allowed(setups)
+
+
+def test_context_is_not_allowed_by_default():
+    context = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=False
+    )
+    setups = {}
+
+    assert not context.is_allowed(setups)
 
 
 def test_context_is_not_allowed():


### PR DESCRIPTION
**Description**
Contexts can now be allowed by default. This behavior now replaces the notion of `parent=standard`.
For now, only *strict* context should be allowed by default.

**Tests**
Fixed relevant unit tests and added new ones

**Alternatives**
Use `parent=standard`. We want to remove the *standard* context in the next PR, so this is not an option.

**Additional context**
Python 3.9, Windows.