### PR TITLE
Non empty sources in commands map

### DIFF
--- a/src/statue/config/configuration.py
+++ b/src/statue/config/configuration.py
@@ -34,9 +34,11 @@ class Configuration:
         """
         commands_map = CommandsMap()
         for source in sources:
-            commands_map[str(source)] = self.build_commands(
+            commands = self.build_commands(
                 CommandsFilter.merge(commands_filter, self.sources_repository[source])
             )
+            if len(commands) != 0:
+                commands_map[str(source)] = commands
         return commands_map
 
     def build_commands(self, commands_filter: CommandsFilter) -> List[Command]:

--- a/tests/configuration/test_configuration_build_commands_map.py
+++ b/tests/configuration/test_configuration_build_commands_map.py
@@ -104,7 +104,7 @@ def test_get_commands_map_with_no_commands(mock_build_commands):
     commands_map = configuration.build_commands_map(
         sources=[Path(SOURCE1), Path(SOURCE2)], commands_filter=commands_filter
     )
-    assert commands_map == CommandsMap({SOURCE1: [], SOURCE2: []})
+    assert commands_map == CommandsMap()
     assert_calls(mock_build_commands, [call(commands_filter), call(commands_filter)])
 
 


### PR DESCRIPTION
**Description**
Make sure that when building commands all sources have at least one command

**Tests**
Fixed relevant unit tests

**Alternatives**
Not relevant

**Additional context**
Python 3.9, Windows