### PR TITLE
Cache is now an object inside configuration

### DIFF
--- a/src/statue/cache.py
+++ b/src/statue/cache.py
@@ -1,74 +1,101 @@
 """Module for cache related methods."""
 import time
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from statue.constants import HISTORY_SIZE
 from statue.evaluation import Evaluation
+from statue.exceptions import CacheError
 
 
 class Cache:
-    """Cache singleton."""
+    """Cache files repository."""
 
-    @classmethod
-    def cache_dir(cls) -> Path:
+    def __init__(
+        self, cache_root_directory: Optional[Path] = None, size: int = HISTORY_SIZE
+    ):
         """
-        Directory of cache files. Created if missing.
+        Initialize cache.
 
-        :return: Location path of the cache directory
-        :rtype: Path
+        :param cache_root_directory: Optional root directory for caching
+        :type cache_root_directory: Optional[Path]
+        :param size: Number of evaluations to save
+        :type size: int
         """
-        return cls.__ensure_dir_exists(Path.cwd() / ".statue")
+        self.cache_root_directory = cache_root_directory
+        self.history_size = size
 
-    @classmethod
-    def evaluations_dir(cls) -> Path:
+    @property
+    def cache_root_directory(self) -> Optional[Path]:
+        """Root directory for caching."""
+        return self._cache_root_directory
+
+    @cache_root_directory.setter
+    def cache_root_directory(self, cache_dir: Optional[Path]):
+        """
+        Set root directory for caching.
+
+        :param cache_dir: Root directory for caching
+        :type cache_dir: Optional[Path]
+        """
+        self._cache_root_directory = cache_dir
+        if cache_dir is not None:
+            self.__ensure_dir_exists(cache_dir)
+
+    @property
+    def evaluations_dir(self) -> Optional[Path]:
         """
         Directory of cache files. Created if missing.
 
         :return: Location path of the previous evaluations cache directory
         :rtype: Path
         """
-        return cls.__ensure_dir_exists(cls.cache_dir() / "evaluations")
+        if self.cache_root_directory is None:
+            return None
+        return self.__ensure_dir_exists(self.cache_root_directory / "evaluations")
 
-    @classmethod
-    def all_evaluation_paths(cls) -> List[Path]:
+    @property
+    def all_evaluation_paths(self) -> List[Path]:
         """
         Get all evaluation paths, ordered from recent to last.
 
         :return: List of all previous evaluations paths
         :rtype: List[Path]
         """
-        evaluations_files = list(cls.evaluations_dir().iterdir())
-        evaluations_files.sort(key=cls.extract_time_stamp_from_path, reverse=True)
+        if self.evaluations_dir is None:
+            return []
+        evaluations_files = list(self.evaluations_dir.iterdir())
+        evaluations_files.sort(key=self.extract_time_stamp_from_path, reverse=True)
         return evaluations_files
 
-    @classmethod
-    def evaluation_path(cls, n: int):  # pylint: disable=invalid-name
+    @property
+    def recent_evaluation_path(self) -> Optional[Path]:
+        """
+        Get last evaluation result path.
+
+        :return: Most recent evaluation path
+        :rtype: Optional[Path]
+        """
+        return self.evaluation_path(0)
+
+    def evaluation_path(self, n: int) -> Path:  # pylint: disable=invalid-name
         """
         Get the nth most recent evaluation result path.
 
         :param n: Evaluation index
         :type n: int
-        :return: Evaluation path of the nth evalaution
+        :return: Evaluation path of the nth evaluation
         :rtype: Path
+        :raises IndexError: Raised when given index does not match any evaluation
         """
-        evaluations_files = cls.all_evaluation_paths()
-        if n >= len(evaluations_files):
-            return None
+        evaluations_files = self.all_evaluation_paths
+        if n < 0 or n >= len(evaluations_files):
+            raise IndexError(
+                "Could not get the desired evaluation due to invalid index"
+            )
         return evaluations_files[n]
 
-    @classmethod
-    def recent_evaluation_path(cls) -> Path:
-        """
-        Get last evaluation result path.
-
-        :return: Most recent evaluation path
-        :rtype: Path
-        """
-        return cls.evaluation_path(0)
-
-    @classmethod
-    def save_evaluation(cls, evaluation: Evaluation):
+    def save_evaluation(self, evaluation: Evaluation):
         """
         Save evaluation to cache.
 
@@ -76,10 +103,14 @@ class Cache:
 
         :param evaluation: Evaluation instance to be saved
         :type evaluation: Evaluation
+        :raises CacheError: raised when trying to save evaluation when no
+            root directory was set
         """
+        if self.evaluations_dir is None:
+            raise CacheError("Cache directory was not specified")
         file_name = f"evaluation-{int(time.time())}.json"
-        evaluation.save_as_json(cls.evaluations_dir() / file_name)
-        cls.__remove_old_evaluations()
+        evaluation.save_as_json(self.evaluations_dir / file_name)
+        self.__remove_old_evaluations()
 
     @classmethod
     def extract_time_stamp_from_path(cls, evaluation_path: Path) -> int:
@@ -93,15 +124,14 @@ class Cache:
         """
         return int(evaluation_path.stem.split("-")[-1])
 
-    @classmethod
-    def __ensure_dir_exists(cls, dir_path: Path) -> Path:
-        dir_path.mkdir(exist_ok=True)
-        return dir_path
+    def __remove_old_evaluations(self):
+        evaluation_files = self.all_evaluation_paths
+        if len(evaluation_files) <= self.history_size:
+            return
+        for evaluation_file in evaluation_files[self.history_size :]:
+            evaluation_file.unlink()
 
     @classmethod
-    def __remove_old_evaluations(cls):
-        evaluation_files = cls.all_evaluation_paths()
-        if len(evaluation_files) <= HISTORY_SIZE:
-            return
-        for evaluation_file in evaluation_files[HISTORY_SIZE:]:
-            evaluation_file.unlink()
+    def __ensure_dir_exists(cls, dir_path: Path) -> Path:
+        dir_path.mkdir(parents=True, exist_ok=True)
+        return dir_path

--- a/src/statue/cli/cli.py
+++ b/src/statue/cli/cli.py
@@ -1,6 +1,6 @@
 """Main CLI for statue."""
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import click
 
@@ -20,12 +20,23 @@ pass_configuration = click.make_pass_decorator(Configuration)
     type=click.Path(exists=True, dir_okay=False),
     help="Statue configuration file.",
 )
+@click.option(
+    "--cache-dir",
+    envvar="STATUE_CACHE_CONFIG",
+    type=click.Path(exists=True, file_okay=False),
+    help="Statue caching directory path",
+)
 @click.pass_context
-def statue_cli(ctx, config: Optional[str]) -> None:
+def statue_cli(
+    ctx, config: Optional[Union[str, Path]], cache_dir: Optional[Union[str, Path]]
+) -> None:
     """Statue is a static code analysis tools orchestrator."""
     config_path = Path(config) if config is not None else None
+    cache_dir = Path(cache_dir) if cache_dir is not None else None
     try:
-        ctx.obj = ConfigurationBuilder.build_configuration_from_file(config_path)
+        ctx.obj = ConfigurationBuilder.build_configuration_from_file(
+            statue_configuration_path=config_path, cache_dir=cache_dir
+        )
     except MissingConfiguration as error:
         click.echo(click.style(error))
         ctx.exit(3)

--- a/src/statue/cli/run.py
+++ b/src/statue/cli/run.py
@@ -6,7 +6,6 @@ from typing import List, Optional, Sequence, Union
 
 import click
 
-from statue.cache import Cache
 from statue.cli.cli import pass_configuration, statue_cli
 from statue.cli.common_flags import (
     allow_option,
@@ -172,7 +171,7 @@ def run_cli(  # pylint: disable=too-many-arguments
         click.echo(boxed_string("Evaluation"))
         click.echo(evaluation_string(evaluation, verbosity=verbosity))
     if cache:
-        Cache.save_evaluation(evaluation)
+        configuration.cache.save_evaluation(evaluation)
     if output is not None:
         evaluation.save_as_json(output)
     click.echo()
@@ -232,7 +231,7 @@ def __get_commands_map(  # pylint: disable=too-many-arguments
                 contexts=context, allowed_commands=allow, denied_commands=deny
             ),
         )
-    evaluation_path = Cache.evaluation_path(previous - 1)
+    evaluation_path = configuration.cache.evaluation_path(previous - 1)
     if evaluation_path is None or not evaluation_path.exists():
         return None
     evaluation = Evaluation.load_from_file(evaluation_path)

--- a/src/statue/config/configuration.py
+++ b/src/statue/config/configuration.py
@@ -1,7 +1,8 @@
 """Get Statue global configuration."""
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
+from statue.cache import Cache
 from statue.command import Command
 from statue.commands_filter import CommandsFilter
 from statue.commands_map import CommandsMap
@@ -13,8 +14,14 @@ from statue.config.sources_repository import SourcesRepository
 class Configuration:
     """Configuration singleton for statue."""
 
-    def __init__(self):
-        """Initialize configuration."""
+    def __init__(self, cache_root_directory: Optional[Path] = None):
+        """
+        Initialize configuration.
+
+        :param cache_root_directory: Root directory for caching
+        :type cache_root_directory: Optional[Path]
+        """
+        self.cache = Cache(cache_root_directory)
         self.contexts_repository = ContextsRepository()
         self.sources_repository = SourcesRepository()
         self.commands_repository = CommandsRepository()

--- a/src/statue/config/configuration_builder.py
+++ b/src/statue/config/configuration_builder.py
@@ -16,6 +16,7 @@ class ConfigurationBuilder:
     def build_configuration_from_file(
         cls,
         statue_configuration_path: Optional[Path] = None,
+        cache_dir: Optional[Path] = None,
     ) -> Configuration:
         """
         Load statue configuration.
@@ -25,7 +26,9 @@ class ConfigurationBuilder:
 
         :param statue_configuration_path: User-defined file path containing
             repository-specific configurations
-        :type statue_configuration_path: None, str or Path
+        :type statue_configuration_path: Optional[Path]
+        :param cache_dir: Optional Caching directory
+        :type cache_dir: Optional[Path]
         :return: Configuration instance
         :rtype: Configuration
         :raises MissingConfiguration: Raised when could not load
@@ -43,7 +46,12 @@ class ConfigurationBuilder:
             if statue_configuration_path.exists()
             else {}
         )
-        configuration = Configuration()
+        cache_dir = (
+            cls.cache_path(statue_configuration_path.parent)
+            if cache_dir is None
+            else cache_dir
+        )
+        configuration = Configuration(cache_root_directory=cache_dir)
         if not statue_config.get(OVERRIDE, False):
             if default_configuration_path.exists():
                 cls.update_from_config(
@@ -100,3 +108,15 @@ class ConfigurationBuilder:
         :rtype: Path
         """
         return directory / "statue.toml"
+
+    @classmethod
+    def cache_path(cls, directory: Path) -> Path:
+        """
+        Default caching directory for statue history saving.
+
+        :param directory: Directory in which cache directory will be created
+        :type directory: Path
+        :return: Cache directory
+        :rtype: Path
+        """
+        return directory / ".statue"

--- a/src/statue/exceptions.py
+++ b/src/statue/exceptions.py
@@ -66,3 +66,7 @@ class CommandExecutionError(StatueException):
         super().__init__(
             f'Cannot execute "{command_name}" because it is not installed.'
         )
+
+
+class CacheError(StatueException):
+    """Cache related exception."""

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,7 +1,17 @@
 import pytest
 from click.testing import CliRunner
 
+from statue.cache import Cache
+
 
 @pytest.fixture
 def cli_runner():
     return CliRunner()
+
+
+# Cache Mocks
+
+
+@pytest.fixture
+def mock_cache_extract_time_stamp_from_path(mocker):
+    return mocker.patch.object(Cache, "extract_time_stamp_from_path")

--- a/tests/cli/history/test_history_clear.py
+++ b/tests/cli/history/test_history_clear.py
@@ -6,8 +6,9 @@ import pytest
 from statue.cli import statue_cli
 
 
-def test_history_clear_empty_history(cli_runner, mock_cache_all_evaluation_paths):
-    mock_cache_all_evaluation_paths.return_value = []
+def test_history_clear_empty_history(cli_runner, mock_build_configuration_from_file):
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.all_evaluation_paths = []
 
     result = cli_runner.invoke(statue_cli, ["history", "clear"])
 
@@ -17,12 +18,12 @@ def test_history_clear_empty_history(cli_runner, mock_cache_all_evaluation_paths
 
 def test_history_clear_confirmed(
     cli_runner,
-    mock_cache_all_evaluation_paths,
     mock_build_configuration_from_file,
 ):
     number_of_evaluations = random.randint(1, 5)
     evaluation_paths = [mock.Mock() for _ in range(number_of_evaluations)]
-    mock_cache_all_evaluation_paths.return_value = evaluation_paths
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.all_evaluation_paths = evaluation_paths
 
     result = cli_runner.invoke(statue_cli, ["history", "clear"], input="y")
 
@@ -39,12 +40,12 @@ def test_history_clear_confirmed(
 
 def test_history_clear_not_confirmed(
     cli_runner,
-    mock_cache_all_evaluation_paths,
     mock_build_configuration_from_file,
 ):
     number_of_evaluations = random.randint(1, 5)
     evaluation_paths = [mock.Mock() for _ in range(number_of_evaluations)]
-    mock_cache_all_evaluation_paths.return_value = evaluation_paths
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.all_evaluation_paths = evaluation_paths
 
     result = cli_runner.invoke(statue_cli, ["history", "clear"], input="n")
 
@@ -63,12 +64,12 @@ def test_history_clear_not_confirmed(
 def test_history_clear_forced(
     force_flag,
     cli_runner,
-    mock_cache_all_evaluation_paths,
     mock_build_configuration_from_file,
 ):
     number_of_evaluations = random.randint(1, 5)
     evaluation_paths = [mock.Mock() for _ in range(number_of_evaluations)]
-    mock_cache_all_evaluation_paths.return_value = evaluation_paths
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.all_evaluation_paths = evaluation_paths
 
     result = cli_runner.invoke(statue_cli, ["history", "clear", force_flag])
 
@@ -85,13 +86,13 @@ def test_history_clear_forced(
 def test_history_clear_limited(
     limit_flag,
     cli_runner,
-    mock_cache_all_evaluation_paths,
     mock_build_configuration_from_file,
 ):
     limited_number = 3
     number_of_evaluations = limited_number + random.randint(1, 5)
     evaluation_paths = [mock.Mock() for _ in range(number_of_evaluations)]
-    mock_cache_all_evaluation_paths.return_value = evaluation_paths
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.all_evaluation_paths = evaluation_paths
 
     result = cli_runner.invoke(
         statue_cli, ["history", "clear", limit_flag, limited_number], input="y"

--- a/tests/cli/history/test_history_list.py
+++ b/tests/cli/history/test_history_list.py
@@ -180,12 +180,12 @@ def test_history_list(
     evaluation_datetimes,
     output,
     cli_runner,
-    mock_cache_all_evaluation_paths,
     mock_evaluation_load_from_file,
     mock_cache_extract_time_stamp_from_path,
     mock_build_configuration_from_file,
 ):
-    mock_cache_all_evaluation_paths.return_value = [
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.all_evaluation_paths = [
         f"evaluation_{uuid.uuid4()}.json" for _ in range(len(evaluations))
     ]
     mock_evaluation_load_from_file.side_effect = evaluations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import mock
 import pytest
 
-from statue.cache import Cache
 from statue.config.configuration import Configuration
 from statue.config.configuration_builder import ConfigurationBuilder
 from statue.evaluation import Evaluation
@@ -36,6 +35,7 @@ def mock_build_configuration_from_file(mocker):
         ConfigurationBuilder, "build_configuration_from_file"
     )
     builder_mock.return_value = Configuration()
+    builder_mock.return_value.cache = mock.Mock()
     builder_mock.return_value.build_commands = mock.Mock()
     builder_mock.return_value.build_commands_map = mock.Mock()
     return builder_mock
@@ -47,34 +47,6 @@ def mock_cwd(mocker, tmpdir_factory):
     cwd_method_mock = mocker.patch.object(Path, "cwd")
     cwd_method_mock.return_value = cwd
     return cwd
-
-
-# Cache Mocks
-
-
-@pytest.fixture
-def mock_cache_save_evaluation(mocker):
-    return mocker.patch.object(Cache, "save_evaluation")
-
-
-@pytest.fixture
-def mock_cache_evaluation_path(mocker):
-    return mocker.patch.object(Cache, "evaluation_path")
-
-
-@pytest.fixture
-def mock_cache_all_evaluation_paths(mocker):
-    return mocker.patch.object(Cache, "all_evaluation_paths")
-
-
-@pytest.fixture
-def mock_cache_recent_evaluation_path(mocker):
-    return mocker.patch.object(Cache, "recent_evaluation_path")
-
-
-@pytest.fixture
-def mock_cache_extract_time_stamp_from_path(mocker):
-    return mocker.patch.object(Cache, "extract_time_stamp_from_path")
 
 
 # Evaluation Mocks

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,40 +1,62 @@
 import random
 from unittest import mock
 
+import pytest
+from pytest_cases import parametrize
+
 from statue.cache import Cache
 from statue.constants import HISTORY_SIZE
+from statue.exceptions import CacheError
 
 
-def test_create_cache_dir(mock_cwd):
-    expected_cache_dir = mock_cwd / ".statue"
-    assert not expected_cache_dir.exists()
-    assert Cache.cache_dir() == expected_cache_dir
-    assert expected_cache_dir.exists()
+def test_cache_constructor_with_none_root_directory(tmp_path):
+    cache = Cache()
+    assert cache.cache_root_directory is None
+    assert cache.evaluations_dir is None
+    assert not cache.all_evaluation_paths
 
 
-def test_cache_dir_already_exist(mock_cwd):
-    expected_cache_dir = mock_cwd / ".statue"
-    expected_cache_dir.mkdir()
-    assert Cache.cache_dir() == expected_cache_dir
-    assert expected_cache_dir.exists()
+def test_cache_constructor_with_non_existing_directory(tmp_path):
+    cache_dir = tmp_path / "cache"
+    assert not cache_dir.exists()
+
+    cache = Cache(cache_dir)
+    assert cache.cache_root_directory == cache_dir
+    assert cache_dir.exists()
+    assert cache.evaluations_dir == cache_dir / "evaluations"
+    assert cache.evaluations_dir.exists()
+    assert not cache.all_evaluation_paths
 
 
-def test_create_evaluations_dir(mock_cwd):
-    expected_evaluations_dir = mock_cwd / ".statue" / "evaluations"
-    assert not expected_evaluations_dir.exists()
-    assert Cache.evaluations_dir() == expected_evaluations_dir
-    assert expected_evaluations_dir.exists()
+def test_cache_constructor_with_existing_directory(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    cache = Cache(cache_dir)
+
+    assert cache.cache_root_directory == cache_dir
+    assert cache_dir.exists()
+    assert cache.evaluations_dir == cache_dir / "evaluations"
+    assert cache.evaluations_dir.exists()
+    assert not cache.all_evaluation_paths
 
 
-def test_evaluations_dir_already_exist(mock_cwd):
-    expected_evaluations_dir = mock_cwd / ".statue" / "evaluations"
-    expected_evaluations_dir.mkdir(parents=True)
-    assert Cache.evaluations_dir() == expected_evaluations_dir
-    assert expected_evaluations_dir.exists()
+def test_cache_constructor_with_evaluations_directory_already_existing(tmp_path):
+    cache_dir = tmp_path / "cache"
+    (cache_dir / "evaluations").mkdir(parents=True)
+
+    cache = Cache(cache_dir)
+
+    assert cache.cache_root_directory == cache_dir
+    assert cache_dir.exists()
+    assert cache.evaluations_dir == cache_dir / "evaluations"
+    assert cache.evaluations_dir.exists()
+    assert not cache.all_evaluation_paths
 
 
-def test_all_evaluations_paths(mock_cwd):
-    evaluations_dir = mock_cwd / ".statue" / "evaluations"
+def test_cache_constructor_with_existing_evaluations(tmp_path):
+    cache_dir = tmp_path / "cache"
+    evaluations_dir = cache_dir / "evaluations"
     evaluations_dir.mkdir(parents=True)
     evaluation_paths = [
         evaluations_dir / "evaluation-1000.json",
@@ -47,59 +69,41 @@ def test_all_evaluations_paths(mock_cwd):
     ]
     for evaluation_file in evaluation_paths:
         evaluation_file.touch()
-    assert Cache.all_evaluation_paths() == evaluation_paths
+
+    cache = Cache(cache_dir)
+
+    assert cache.cache_root_directory == cache_dir
+    assert cache_dir.exists()
+    assert cache.evaluations_dir == cache_dir / "evaluations"
+    assert cache.evaluations_dir.exists()
+    assert cache.all_evaluation_paths == evaluation_paths
+    assert cache.recent_evaluation_path == evaluation_paths[0]
+    for i, evaluation_path in enumerate(evaluation_paths):
+        assert cache.evaluation_path(i) == evaluation_path
 
 
-def test_numbered_evaluation_path(mock_cwd):
-    evaluations_dir = mock_cwd / ".statue" / "evaluations"
-    evaluations_dir.mkdir(parents=True)
-    evaluation_paths = [
-        evaluations_dir / "evaluation-3.json",
-        evaluations_dir / "evaluation-2.json",
-        evaluations_dir / "evaluation-1.json",
-    ]
-    for evaluation_file in evaluation_paths:
-        evaluation_file.touch()
-    for i, evaluation_file in enumerate(evaluation_paths):
-        assert Cache.evaluation_path(i) == evaluation_file
-    assert Cache.evaluation_path(len(evaluation_paths)) is None
-
-
-def test_recent_evaluation_path(mock_cwd):
-    evaluations_dir = mock_cwd / ".statue" / "evaluations"
-    evaluations_dir.mkdir(parents=True)
-    evaluation_paths = [
-        evaluations_dir / "evaluation-3.json",
-        evaluations_dir / "evaluation-2.json",
-        evaluations_dir / "evaluation-1.json",
-    ]
-    for evaluation_file in evaluation_paths:
-        evaluation_file.touch()
-    assert Cache.recent_evaluation_path() == evaluation_paths[0]
-
-
-def test_recent_evaluation_path_when_dir_is_empty(mock_cwd):
-    evaluations_dir = mock_cwd / ".statue" / "evaluations"
-    evaluations_dir.mkdir(parents=True)
-    assert Cache.recent_evaluation_path() is None
-
-
-def test_save_evaluation(mock_cwd, mock_time):
+def test_save_evaluation(tmp_path, mock_time):
     time = 12300566
-    evaluations_dir = mock_cwd / ".statue" / "evaluations"
+    cache_dir = tmp_path / "cache"
+    evaluations_dir = cache_dir / "evaluations"
+    evaluations_dir.mkdir(parents=True)
     evaluation_file = evaluations_dir / f"evaluation-{time}.json"
     mock_time.return_value = time
 
     evaluation = mock.Mock()
     evaluation.save_as_json.side_effect = lambda path: path.touch()
 
-    Cache.save_evaluation(evaluation)
+    cache = Cache(cache_dir)
+
+    assert not evaluation_file.exists()
+    cache.save_evaluation(evaluation)
     evaluation.save_as_json.assert_called_with(evaluation_file)
     assert evaluation_file.exists()
 
 
-def test_save_evaluation_deletes_old_evaluations(mock_cwd, mock_time):
-    evaluations_dir = mock_cwd / ".statue" / "evaluations"
+def test_save_evaluation_deletes_old_evaluations(tmp_path, mock_time):
+    cache_dir = tmp_path / "cache"
+    evaluations_dir = cache_dir / "evaluations"
     evaluations_dir.mkdir(parents=True)
 
     time_stamps = list(random.choices(range(1_000_000), k=HISTORY_SIZE + 1))
@@ -119,10 +123,44 @@ def test_save_evaluation_deletes_old_evaluations(mock_cwd, mock_time):
 
     assert not recent_evaluation_file.exists()
 
-    Cache.save_evaluation(evaluation)
+    cache = Cache(cache_dir)
+    cache.save_evaluation(evaluation)
     evaluation.save_as_json.assert_called_with(recent_evaluation_file)
 
     assert recent_evaluation_file.exists()
     for i, evaluation_file in enumerate(old_evaluations[:-1]):
         assert evaluation_file.exists(), f"The {i}th old file does not exist."
     assert not old_evaluations[-1].exists()
+
+
+def test_cache_save_evaluation_fails_when_no_root_dir_was_set():
+    cache = Cache()
+    evaluation = mock.Mock()
+
+    with pytest.raises(CacheError, match="^Cache directory was not specified$"):
+        cache.save_evaluation(evaluation)
+
+
+@parametrize(argnames="invalid_evaluation_index", argvalues=[-1, 10])
+def test_cache_get_evaluation_with_invalid_context_(tmp_path, invalid_evaluation_index):
+    cache_dir = tmp_path / "cache"
+    evaluations_dir = cache_dir / "evaluations"
+    evaluations_dir.mkdir(parents=True)
+    evaluation_paths = [
+        evaluations_dir / "evaluation-1000.json",
+        evaluations_dir / "evaluation-999.json",
+        evaluations_dir / "evaluation-900.json",
+        evaluations_dir / "evaluation-889.json",
+        evaluations_dir / "evaluation-700.json",
+        evaluations_dir / "evaluation-88.json",
+        evaluations_dir / "evaluation-70.json",
+    ]
+    for evaluation_file in evaluation_paths:
+        evaluation_file.touch()
+
+    cache = Cache(cache_dir)
+
+    with pytest.raises(
+        IndexError, match="^Could not get the desired evaluation due to invalid index$"
+    ):
+        cache.evaluation_path(invalid_evaluation_index)


### PR DESCRIPTION
**Description**
`Cache` is now an object inside `Configuration` instead of a singleton

**Tests**
Fixed relevant unit tests and used `statue history` to see it updates correctly

**Alternatives**
Not relevant

**Additional context**
Python 3.9, Windows