### PR TITLE
Elaborate context show

### DIFF
--- a/src/statue/cli/contexts.py
+++ b/src/statue/cli/contexts.py
@@ -45,6 +45,36 @@ def show_contexts_cli(
             click.echo(
                 f"{bullet_style('Parent')} - {name_style(context_instance.parent.name)}"
             )
+        required_by = [
+            name_style(command_builder.name)
+            for command_builder in configuration.commands_repository
+            if any(
+                context_instance.is_matching(required_context)
+                for required_context in command_builder.required_contexts
+            )
+        ]
+        if len(required_by) != 0:
+            click.echo(f"{bullet_style('Required by')} - {', '.join(required_by)}")
+        allowed_for = [
+            name_style(command_builder.name)
+            for command_builder in configuration.commands_repository
+            if any(
+                context_instance.is_matching(allowed_context)
+                for allowed_context in command_builder.allowed_contexts
+            )
+        ]
+        if len(allowed_for) != 0:
+            click.echo(f"{bullet_style('Allowed for')} - {', '.join(allowed_for)}")
+        specified_for = [
+            name_style(command_builder.name)
+            for command_builder in configuration.commands_repository
+            if any(
+                context_instance.is_matching(specified_context)
+                for specified_context in command_builder.specified_contexts
+            )
+        ]
+        if len(specified_for) != 0:
+            click.echo(f"{bullet_style('Specified for')} - {', '.join(specified_for)}")
     except UnknownContext:
         click.echo(f'Could not find the context "{context_name}".')
         ctx.exit(1)

--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -145,12 +145,17 @@ class CommandBuilder:  # pylint: disable=too-many-instance-attributes
     )
 
     @property
+    def specified_contexts(self) -> List[str]:
+        """Contexts names list with arguments specifications."""
+        return list(self.contexts_specifications.keys())
+
+    @property
     def available_contexts(self) -> List[str]:
         """Contexts which are available to use according to this command."""
         return [
             *self.required_contexts,
             *self.allowed_contexts,
-            *self.contexts_specifications.keys(),
+            *self.specified_contexts,
         ]
 
     def validate_contexts(self, *contexts: Context):

--- a/tests/command_builder/test_command_builder_basics.py
+++ b/tests/command_builder/test_command_builder_basics.py
@@ -1,0 +1,162 @@
+from statue.command_builder import CommandBuilder, ContextSpecification
+from tests.constants import (
+    ARG1,
+    ARG2,
+    ARG3,
+    ARG4,
+    COMMAND1,
+    COMMAND_HELP_STRING1,
+    CONTEXT1,
+    CONTEXT2,
+    CONTEXT3,
+    CONTEXT4,
+    CONTEXT5,
+    CONTEXT6,
+)
+
+
+def test_command_builder_empty_constructor():
+    command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+
+    assert command_builder.name == COMMAND1
+    assert command_builder.help == COMMAND_HELP_STRING1
+    assert not command_builder.default_args
+    assert command_builder.version is None
+    assert not command_builder.required_contexts
+    assert not command_builder.allowed_contexts
+    assert not command_builder.specified_contexts
+    assert not command_builder.available_contexts
+    assert command_builder.contexts_specifications == {}
+
+
+def test_command_builder_with_version():
+    version = "6.5.2"
+    command_builder = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
+    )
+
+    assert command_builder.name == COMMAND1
+    assert command_builder.help == COMMAND_HELP_STRING1
+    assert not command_builder.default_args
+    assert command_builder.version == version
+    assert not command_builder.required_contexts
+    assert not command_builder.allowed_contexts
+    assert not command_builder.specified_contexts
+    assert not command_builder.available_contexts
+    assert command_builder.contexts_specifications == {}
+
+
+def test_command_builder_with_default_args():
+    command_builder = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, default_args=[ARG1, ARG2]
+    )
+
+    assert command_builder.name == COMMAND1
+    assert command_builder.help == COMMAND_HELP_STRING1
+    assert command_builder.default_args == [ARG1, ARG2]
+    assert command_builder.version is None
+    assert not command_builder.required_contexts
+    assert not command_builder.allowed_contexts
+    assert not command_builder.specified_contexts
+    assert not command_builder.available_contexts
+    assert command_builder.contexts_specifications == {}
+
+
+def test_command_builder_with_required_contexts():
+    command_builder = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[CONTEXT1, CONTEXT2]
+    )
+
+    assert command_builder.name == COMMAND1
+    assert command_builder.help == COMMAND_HELP_STRING1
+    assert not command_builder.default_args
+    assert command_builder.version is None
+    assert command_builder.required_contexts == [CONTEXT1, CONTEXT2]
+    assert not command_builder.allowed_contexts
+    assert not command_builder.specified_contexts
+    assert command_builder.available_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.contexts_specifications == {}
+
+
+def test_command_builder_with_allowed_contexts():
+    command_builder = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[CONTEXT1, CONTEXT2]
+    )
+
+    assert command_builder.name == COMMAND1
+    assert command_builder.help == COMMAND_HELP_STRING1
+    assert not command_builder.default_args
+    assert command_builder.version is None
+    assert not command_builder.required_contexts
+    assert command_builder.allowed_contexts == [CONTEXT1, CONTEXT2]
+    assert not command_builder.specified_contexts
+    assert command_builder.available_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.contexts_specifications == {}
+
+
+def test_command_builder_with_specified_contexts():
+    context_specification1, context_specification2 = (
+        ContextSpecification(args=[ARG1]),
+        ContextSpecification(add_args=[ARG2]),
+    )
+    command_builder = CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={
+            CONTEXT1: context_specification1,
+            CONTEXT2: context_specification2,
+        },
+    )
+
+    assert command_builder.name == COMMAND1
+    assert command_builder.help == COMMAND_HELP_STRING1
+    assert not command_builder.default_args
+    assert command_builder.version is None
+    assert not command_builder.required_contexts
+    assert not command_builder.allowed_contexts
+    assert command_builder.specified_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.available_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.contexts_specifications == {
+        CONTEXT1: context_specification1,
+        CONTEXT2: context_specification2,
+    }
+
+
+def test_command_builder_with_all_fields():
+    context_specification1, context_specification2 = (
+        ContextSpecification(args=[ARG3]),
+        ContextSpecification(add_args=[ARG4]),
+    )
+    version = "4.5.1"
+    command_builder = CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        default_args=[ARG1, ARG2],
+        version=version,
+        required_contexts=[CONTEXT1, CONTEXT2],
+        allowed_contexts=[CONTEXT3, CONTEXT4],
+        contexts_specifications={
+            CONTEXT5: context_specification1,
+            CONTEXT6: context_specification2,
+        },
+    )
+
+    assert command_builder.name == COMMAND1
+    assert command_builder.help == COMMAND_HELP_STRING1
+    assert command_builder.default_args == [ARG1, ARG2]
+    assert command_builder.version == version
+    assert command_builder.required_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.allowed_contexts == [CONTEXT3, CONTEXT4]
+    assert command_builder.specified_contexts == [CONTEXT5, CONTEXT6]
+    assert command_builder.available_contexts == [
+        CONTEXT1,
+        CONTEXT2,
+        CONTEXT3,
+        CONTEXT4,
+        CONTEXT5,
+        CONTEXT6,
+    ]
+    assert command_builder.contexts_specifications == {
+        CONTEXT5: context_specification1,
+        CONTEXT6: context_specification2,
+    }


### PR DESCRIPTION
**Description**
When using `statue context show` it prints also commands that are required, allowed, or specified for the given context.
This brings more information for the user

**Tests**
Added relevant unit tests and ran `statue context show` with multiple contexts to see it works.

**Alternatives**
Not relevant.

**Additional context**
Python 3.9, Windows