### PR TITLE
Pylint enable useless supression

### DIFF
--- a/src/statue/cli/config.py
+++ b/src/statue/cli/config.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-arguments
 """Config CLI."""
 import re
 from collections import OrderedDict

--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -131,7 +131,7 @@ class ContextSpecification:
 
 
 @dataclass
-class CommandBuilder:  # pylint: disable=too-many-instance-attributes
+class CommandBuilder:
     """Command builder as specified in configuration."""
 
     name: str

--- a/src/statue/resources/defaults.toml
+++ b/src/statue/resources/defaults.toml
@@ -62,7 +62,12 @@ allowed_contexts = ["test"]
 add_args = ["--strict"]
 
 [commands.pylint]
-args = ["--ignore-imports=y", "--disable=bad-continuation"]
+args = [
+    "--ignore-imports=y",
+    "--disable=bad-continuation",
+    "--enable=useless-suppression",
+    "--fail-on=useless-suppression"
+]
 help = "Python code linter"
 allowed_contexts = ["documentation"]
 

--- a/src/statue/runner.py
+++ b/src/statue/runner.py
@@ -21,7 +21,7 @@ class EvaluationRunner:  # pylint: disable=too-few-public-methods
     """Evaluation runner interface."""
 
     @abc.abstractmethod
-    def evaluate(  # pylint: disable=unused-argument, no-self-use
+    def evaluate(
         self,
         commands_map: CommandsMap,
         update_func: Optional[Callable[[Evaluation], None]] = None,


### PR DESCRIPTION
**Description**
When using *Pylint*, useless suppressed errors should trigger *Pylint* to fail

**Tests**
Run `statue run` and saw statue fail because of *Pylint*

**Alternatives**
Keep things as they are. This causes us to use unneeded suppression without any reason.

**Additional context**
Python 3.9, Windows