### PR TITLE
Don't load configuration in config cli

### DIFF
--- a/src/statue/cli/cli.py
+++ b/src/statue/cli/cli.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 import click
 
 from statue import __version__
+from statue.cli.common_flags import config_path_option
 from statue.cli.styled_strings import failure_style
 from statue.config.configuration import Configuration
 from statue.config.configuration_builder import ConfigurationBuilder
@@ -15,12 +16,7 @@ pass_configuration = click.make_pass_decorator(Configuration)
 
 @click.group(name="statue", no_args_is_help=True)
 @click.version_option(version=__version__)
-@click.option(
-    "--config",
-    envvar="STATUE_CONFIG",
-    type=click.Path(exists=True, dir_okay=False),
-    help="Statue configuration file.",
-)
+@config_path_option
 @click.option(
     "--cache-dir",
     envvar="STATUE_CACHE",
@@ -29,9 +25,13 @@ pass_configuration = click.make_pass_decorator(Configuration)
 )
 @click.pass_context
 def statue_cli(
-    ctx, config: Optional[Union[str, Path]], cache_dir: Optional[Union[str, Path]]
-) -> None:
+    ctx: click.Context,
+    config: Optional[Union[str, Path]],
+    cache_dir: Optional[Union[str, Path]],
+):
     """Statue is a static code analysis tools orchestrator."""
+    if ctx.invoked_subcommand == "config":
+        return
     config_path = Path(config) if config is not None else None
     cache_dir = Path(cache_dir) if cache_dir is not None else None
     try:

--- a/src/statue/cli/cli.py
+++ b/src/statue/cli/cli.py
@@ -23,7 +23,7 @@ pass_configuration = click.make_pass_decorator(Configuration)
 )
 @click.option(
     "--cache-dir",
-    envvar="STATUE_CACHE_CONFIG",
+    envvar="STATUE_CACHE",
     type=click.Path(exists=True, file_okay=False),
     help="Statue caching directory path",
 )

--- a/src/statue/cli/common_flags.py
+++ b/src/statue/cli/common_flags.py
@@ -3,6 +3,12 @@ import click
 
 from statue.verbosity import DEFAULT_VERBOSITY, SILENT, VERBOSE, VERBOSITIES
 
+config_path_option = click.option(
+    "--config",
+    envvar="STATUE_CONFIG",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Statue configuration file.",
+)
 contexts_option = click.option(
     "-c",
     "--context",

--- a/src/statue/config/configuration_builder.py
+++ b/src/statue/config/configuration_builder.py
@@ -36,7 +36,7 @@ class ConfigurationBuilder:
         """
         default_configuration_path = cls.default_configuration_path()
         if statue_configuration_path is None:
-            statue_configuration_path = cls.configuration_path(Path.cwd())
+            statue_configuration_path = cls.configuration_path()
         if (
             not default_configuration_path.exists()
             and not statue_configuration_path.exists()
@@ -110,7 +110,7 @@ class ConfigurationBuilder:
         return Path(__file__).parent.parent / "resources" / "defaults.toml"
 
     @classmethod
-    def configuration_path(cls, directory: Path) -> Path:
+    def configuration_path(cls, directory: Optional[Path] = None) -> Path:
         """
         Search for configuration file in directory.
 
@@ -119,6 +119,8 @@ class ConfigurationBuilder:
         :return: Configuration path location
         :rtype: Path
         """
+        if directory is None:
+            directory = Path.cwd()
         return directory / "statue.toml"
 
     @classmethod

--- a/tests/cli/config/test_config_fix_versions.py
+++ b/tests/cli/config/test_config_fix_versions.py
@@ -178,14 +178,15 @@ def test_config_fix_version_latest(
     assert result.exit_code == 0
 
 
-def test_config_fix_version_with_direction(
+def test_config_fix_version_with_configuration_path(
     cli_runner,
     mock_build_configuration_from_file,
     tmp_path,
-    mock_cwd,
     mock_toml_load,
     mock_toml_dump,
 ):
+    config_path = tmp_path / "statue.toml"
+    config_path.touch()
     version1 = VERSION1
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1, installed=True, installed_version=version1),
@@ -200,8 +201,11 @@ def test_config_fix_version_with_direction(
     mock_open = mock.mock_open()
     with mock.patch("statue.cli.config.open", mock_open):
         result = cli_runner.invoke(
-            statue_cli, ["config", "fix-versions", "--directory", str(tmp_path)]
+            statue_cli, ["config", "fix-versions", "--config", str(config_path)]
         )
+        assert (
+            result.exit_code == 0
+        ), f"Exited with error code and exception: {result.exception}"
         mock_toml_load.assert_called_once_with(mock_open.return_value)
         mock_toml_dump.assert_called_once_with(
             {
@@ -210,5 +214,3 @@ def test_config_fix_version_with_direction(
             },
             mock_open.return_value,
         )
-
-    assert result.exit_code == 0

--- a/tests/cli/config/test_interactive_config_init.py
+++ b/tests/cli/config/test_interactive_config_init.py
@@ -91,14 +91,15 @@ def test_interactive_config_init(
     sources,
     inputs,
     expected_config,
-    mock_build_configuration_from_file,
     mock_configuration_path,
-    mock_cwd,
+    tmp_path,
     mock_find_sources,
     mock_toml_dump,
     mock_git_repo,
     cli_runner,
 ):
+    configuration_path = tmp_path / "statue.toml"
+    mock_configuration_path.return_value = configuration_path
     mock_sources = []
     for source in sources:
         mock_source = mock.Mock()
@@ -115,4 +116,4 @@ def test_interactive_config_init(
         mock_configuration_path.return_value, mode="w", encoding="utf-8"
     )
     mock_toml_dump.assert_called_once_with(expected_config, mock_open.return_value)
-    mock_find_sources.assert_called_once_with(mock_cwd, repo=mock_git_repo.return_value)
+    mock_find_sources.assert_called_once_with(tmp_path, repo=mock_git_repo.return_value)

--- a/tests/configuration/configuration_builder/test_configuration_builder_build_from_file.py
+++ b/tests/configuration/configuration_builder/test_configuration_builder_build_from_file.py
@@ -104,7 +104,6 @@ def test_configuration_builder_build_with_no_config_path(
     mock_default_configuration_path,
     mock_config_path,
     mock_cache_path,
-    mock_cwd,
     mock_toml_load,
 ):
     mock_default_configuration_path.touch()
@@ -131,7 +130,7 @@ def test_configuration_builder_build_with_no_config_path(
         mock.call(configuration=configuration, statue_config=default_config),
         mock.call(configuration=configuration, statue_config=statue_config),
     ]
-    mock_config_path.assert_called_once_with(mock_cwd)
+    mock_config_path.assert_called_once_with()
     mock_cache_path.assert_called_once_with(tmp_path)
     assert configuration.cache.cache_root_directory == cache_path
 


### PR DESCRIPTION
**Description**
Configuration shouldn't be loaded when using the `config` cli.

This is due to the fact that most people will use the `config` cli to initialize configuration, which is not present at the moment.

**Tests**
Fixed failed unit tests and ran all `statue config` commands.

**Alternatives**
Not relevant

**Additional context**
Python 3.9, Windows