### PR TITLE
Configuration as dict

### DIFF
--- a/src/statue/command.py
+++ b/src/statue/command.py
@@ -27,7 +27,7 @@ class CommandEvaluation:
         """Join captured output into a single string."""
         return "\n".join(self.captured_output)
 
-    def as_json(self) -> Dict[str, Any]:
+    def as_dict(self) -> Dict[str, Any]:
         """
         Return command evaluation as json dictionary.
 

--- a/src/statue/command.py
+++ b/src/statue/command.py
@@ -47,7 +47,7 @@ class CommandEvaluation:
         )
 
     @classmethod
-    def from_json(cls, command_evaluation: Dict[str, Any]) -> "CommandEvaluation":
+    def from_dict(cls, command_evaluation: Dict[str, Any]) -> "CommandEvaluation":
         """
         Read command evaluation from json dictionary.
 

--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -427,7 +427,7 @@ class CommandBuilder:
         )
 
     @classmethod
-    def from_config(cls, command_name, builder_setups: Dict[str, Any]):
+    def from_dict(cls, command_name, builder_setups: Dict[str, Any]):
         """
         Build command builder according to a given configuration.
 

--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -48,6 +48,25 @@ class ContextSpecification:
             return []
         return args
 
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        Encode context specification as a dictionary.
+
+        This is used in order to serialize the context specification in
+        a configuration file.
+
+        :return: Serialized representation dictionary
+        :rtype: Dict[str, Any]
+        """
+        specification_as_dict: Dict[str, Any] = {}
+        if self.args is not None:
+            specification_as_dict[ARGS] = self.args
+        if self.add_args is not None:
+            specification_as_dict[ADD_ARGS] = self.add_args
+        if self.clear_args:
+            specification_as_dict[CLEAR_ARGS] = True
+        return specification_as_dict
+
     @classmethod
     def validate(  # pylint: disable=too-many-arguments
         cls,
@@ -425,6 +444,33 @@ class CommandBuilder:
                 for context_name, context_specification in builder_setups.items()
             }
         )
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        Encode command builder as a dictionary.
+
+        This is used in order to serialize the command builder in
+        a configuration file.
+
+        :return: Serialized representation dictionary
+        :rtype: Dict[str, Any]
+        """
+        builder_as_dict: Dict[str, Any] = {HELP: self.help}
+        if self.version is not None:
+            builder_as_dict[VERSION] = self.version
+        if len(self.default_args) != 0:
+            builder_as_dict[ARGS] = self.default_args
+        if len(self.required_contexts) != 0:
+            builder_as_dict[REQUIRED_CONTEXTS] = self.required_contexts
+        if len(self.allowed_contexts) != 0:
+            builder_as_dict[ALLOWED_CONTEXTS] = self.allowed_contexts
+        builder_as_dict.update(
+            {
+                context_name: specification.as_dict()
+                for context_name, specification in self.contexts_specifications.items()
+            }
+        )
+        return builder_as_dict
 
     @classmethod
     def from_dict(cls, command_name, builder_setups: Dict[str, Any]):

--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -95,7 +95,7 @@ class ContextSpecification:
             )
 
     @classmethod
-    def from_json(
+    def from_dict(
         cls,
         command_name: str,
         context_specification_setups: Dict[str, Any],
@@ -406,7 +406,7 @@ class CommandBuilder:
         # Copy in order to avoid configuration contamination
         builder_setups = dict(builder_setups)
 
-        self.default_args = ContextSpecification.from_json(
+        self.default_args = ContextSpecification.from_dict(
             command_name=self.name, context_specification_setups=builder_setups
         ).update_args(self.default_args)
 
@@ -417,7 +417,7 @@ class CommandBuilder:
         self.allowed_contexts.extend(builder_setups.pop(ALLOWED_CONTEXTS, []))
         self.contexts_specifications.update(
             {
-                context_name: ContextSpecification.from_json(
+                context_name: ContextSpecification.from_dict(
                     command_name=self.name,
                     context_name=context_name,
                     context_specification_setups=context_specification,

--- a/src/statue/commands_filter.py
+++ b/src/statue/commands_filter.py
@@ -1,7 +1,8 @@
 """Filter commands using simple checks."""
-from typing import Any, Collection, FrozenSet, Optional
+from typing import Any, Collection, Dict, FrozenSet, Optional
 
 from statue.command_builder import CommandBuilder
+from statue.constants import ALLOW_LIST, CONTEXTS, DENY_LIST
 from statue.context import Context
 
 
@@ -111,6 +112,31 @@ class CommandsFilter:
         ):
             return False
         return command_builder.match_contexts(*self.contexts)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        Encode commands filter as a dictionary.
+
+        This is used in order to serialize the commands filter in
+        a configuration file.
+
+        :return: Serialized representation dictionary
+        :rtype: Dict[str, Any]
+        """
+        filter_as_dict = {}
+        if len(self.contexts) != 0:
+            context_names = [context.name for context in self.contexts]
+            context_names.sort()
+            filter_as_dict[CONTEXTS] = context_names
+        if self.allowed_commands is not None:
+            allowed_commands = list(self.allowed_commands)
+            allowed_commands.sort()
+            filter_as_dict[ALLOW_LIST] = allowed_commands
+        if self.denied_commands is not None:
+            denied_commands = list(self.denied_commands)
+            denied_commands.sort()
+            filter_as_dict[DENY_LIST] = denied_commands
+        return filter_as_dict
 
     @classmethod
     def merge(

--- a/src/statue/config/commands_repository.py
+++ b/src/statue/config/commands_repository.py
@@ -97,3 +97,17 @@ class CommandsRepository:
                         command_name=command_name, builder_setups=builder_setups
                     )
                 )
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        Encode commands repository as a dictionary.
+
+        This is used in order to serialize the commands repository in
+        a configuration file.
+
+        :return: Serialized representation dictionary
+        :rtype: Dict[str, Any]
+        """
+        return {
+            command_builder.name: command_builder.as_dict() for command_builder in self
+        }

--- a/src/statue/config/commands_repository.py
+++ b/src/statue/config/commands_repository.py
@@ -93,7 +93,7 @@ class CommandsRepository:
                 self[command_name].update_from_config(builder_setups)
             else:
                 self.add_command_builders(
-                    CommandBuilder.from_config(
+                    CommandBuilder.from_dict(
                         command_name=command_name, builder_setups=builder_setups
                     )
                 )

--- a/src/statue/config/configuration.py
+++ b/src/statue/config/configuration.py
@@ -9,6 +9,7 @@ from statue.commands_map import CommandsMap
 from statue.config.commands_repository import CommandsRepository
 from statue.config.contexts_repository import ContextsRepository
 from statue.config.sources_repository import SourcesRepository
+from statue.constants import COMMANDS, CONTEXTS, GENERAL, MODE, SOURCES
 from statue.runner import RunnerMode
 
 
@@ -70,3 +71,20 @@ class Configuration:
             for command_builder in self.commands_repository
             if commands_filter.pass_filter(command_builder)
         ]
+
+    def as_dict(self):
+        """
+        Encode configuration as a dictionary.
+
+        This is used in order to serialize the configuration to be later saved
+        in a file.
+
+        :return: Serialized representation dictionary
+        :rtype: Dict[str, Any]
+        """
+        return {
+            GENERAL: {MODE: self.default_mode.name.lower()},
+            CONTEXTS: self.contexts_repository.as_dict(),
+            COMMANDS: self.commands_repository.as_dict(),
+            SOURCES: self.sources_repository.as_dict(),
+        }

--- a/src/statue/config/contexts_repository.py
+++ b/src/statue/config/contexts_repository.py
@@ -1,5 +1,5 @@
 """Place for saving all available contexts."""
-from typing import Any, Iterator, MutableMapping
+from typing import Any, Dict, Iterator, MutableMapping
 
 from statue.constants import ALIASES, PARENT
 from statue.context import Context
@@ -134,3 +134,15 @@ class ContextsRepository:
                     "because a context is already defined with this name"
                 )
         return Context(name=context_name, **context_config)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        Encode contexts repository as a dictionary.
+
+        This is used in order to serialize the contexts repository in
+        a configuration file.
+
+        :return: Serialized representation dictionary
+        :rtype: Dict[str, Any]
+        """
+        return {context.name: context.as_dict() for context in self}

--- a/src/statue/config/sources_repository.py
+++ b/src/statue/config/sources_repository.py
@@ -67,6 +67,18 @@ class SourcesRepository:
         """Reset sources repository."""
         self.sources_filters_map.clear()
 
+    def as_dict(self):
+        """
+        Encode sources repository as a dictionary.
+
+        This is used in order to serialize the sources repository in
+        a configuration file.
+
+        :return: Serialized representation dictionary
+        :rtype: Dict[str, Any]
+        """
+        return {str(source): self[source].as_dict() for source in self.sources_list}
+
     def update_from_config(
         self, config: MutableMapping[str, Any], contexts_repository: ContextsRepository
     ):

--- a/src/statue/context.py
+++ b/src/statue/context.py
@@ -1,6 +1,8 @@
 """Context class used for reading commands in various contexts."""
 from dataclasses import dataclass, field
-from typing import Any, List, MutableMapping, Optional
+from typing import Any, Dict, List, MutableMapping, Optional
+
+from statue.constants import ALIASES, ALLOWED_BY_DEFAULT, HELP, PARENT
 
 
 @dataclass
@@ -76,3 +78,21 @@ class Context:
         if self.parent is not None:
             return self.parent.search_context_instructions(setups)
         return None
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        Encode context as a dictionary.
+
+        This is used in order to serialize the context in a configuration file.
+
+        :return: Serialized representation dictionary
+        :rtype: Dict[str, Any]
+        """
+        context_dict: Dict[str, Any] = {HELP: self.help}
+        if len(self.aliases) != 0:
+            context_dict[ALIASES] = self.aliases
+        if self.allowed_by_default:
+            context_dict[ALLOWED_BY_DEFAULT] = True
+        if self.parent is not None:
+            context_dict[PARENT] = self.parent.name
+        return context_dict

--- a/src/statue/evaluation.py
+++ b/src/statue/evaluation.py
@@ -99,7 +99,7 @@ class SourceEvaluation:
         return self.commands_number - self.successful_commands_number
 
     @classmethod
-    def from_json(cls, source_evaluation: Dict[str, Any]) -> "SourceEvaluation":
+    def from_dict(cls, source_evaluation: Dict[str, Any]) -> "SourceEvaluation":
         """
         Read source evaluation from json list.
 
@@ -110,7 +110,7 @@ class SourceEvaluation:
         """
         return SourceEvaluation(
             commands_evaluations=[
-                CommandEvaluation.from_json(command_evaluation)
+                CommandEvaluation.from_dict(command_evaluation)
                 for command_evaluation in source_evaluation["commands_evaluations"]
             ],
             source_execution_duration=source_evaluation["source_execution_duration"],
@@ -278,7 +278,7 @@ class Evaluation:
         :rtype: Evaluation
         """
         with open(input_path, mode="r", encoding=ENCODING) as input_file:
-            return Evaluation.from_json(json.load(input_file))
+            return Evaluation.from_dict(json.load(input_file))
 
     @property
     def commands_map(self) -> CommandsMap:
@@ -324,7 +324,7 @@ class Evaluation:
         return Evaluation(sources_evaluations=failure_dict)
 
     @classmethod
-    def from_json(cls, evaluation: Dict[str, Any]) -> "Evaluation":
+    def from_dict(cls, evaluation: Dict[str, Any]) -> "Evaluation":
         """
         Read evaluation from json dictionary.
 
@@ -335,7 +335,7 @@ class Evaluation:
         """
         return Evaluation(
             sources_evaluations={
-                input_path: SourceEvaluation.from_json(source_evaluation)
+                input_path: SourceEvaluation.from_dict(source_evaluation)
                 for input_path, source_evaluation in evaluation[
                     "sources_evaluations"
                 ].items()

--- a/src/statue/evaluation.py
+++ b/src/statue/evaluation.py
@@ -34,7 +34,7 @@ class SourceEvaluation:
         """
         self.commands_evaluations.append(command_evaluation)
 
-    def as_json(self) -> Dict[str, Any]:
+    def as_dict(self) -> Dict[str, Any]:
         """
         Return source evaluation as json dictionary.
 
@@ -43,7 +43,7 @@ class SourceEvaluation:
         """
         return dict(
             commands_evaluations=[
-                command_evaluation.as_json()
+                command_evaluation.as_dict()
                 for command_evaluation in self.commands_evaluations
             ],
             source_execution_duration=self.source_execution_duration,
@@ -191,14 +191,14 @@ class Evaluation:
         """
         return self.sources_evaluations.items()
 
-    def as_json(self) -> Dict[str, Any]:
+    def as_dict(self) -> Dict[str, Any]:
         """
         Return evaluation as json dictionary.
 
         :return: Self as dictionary
         :rtype: Dict[str, List[Dict[str, Any]]]
         """
-        sources_evaluations = {key: value.as_json() for key, value in self.items()}
+        sources_evaluations = {key: value.as_dict() for key, value in self.items()}
         return dict(
             sources_evaluations=sources_evaluations,
             total_execution_duration=self.total_execution_duration,
@@ -212,7 +212,7 @@ class Evaluation:
         :type output: Path or str
         """
         with open(output, mode="w", encoding=ENCODING) as output_file:
-            json.dump(self.as_json(), output_file, indent=2)
+            json.dump(self.as_dict(), output_file, indent=2)
 
     @property
     def success(self) -> bool:

--- a/tests/command_builder/test_command_builder_dict_encoding.py
+++ b/tests/command_builder/test_command_builder_dict_encoding.py
@@ -199,6 +199,15 @@ def test_command_builder_from_dict_successful(command_builder_dict, command_buil
     assert actual_builder == command_builder
 
 
+@parametrize_with_cases(
+    argnames=["command_builder_dict", "command_builder"],
+    cases=THIS_MODULE,
+    has_tag=SUCCESSFUL_TAG,
+)
+def test_command_builder_as_dict_successful(command_builder_dict, command_builder):
+    assert command_builder.as_dict() == command_builder_dict
+
+
 # Failed tests
 
 

--- a/tests/command_builder/test_command_builder_from_dict.py
+++ b/tests/command_builder/test_command_builder_from_dict.py
@@ -33,57 +33,63 @@ from tests.constants import (
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_simple_command_builder_from_json():
-    json_dict = {HELP: COMMAND_HELP_STRING1}
+def case_simple_command_builder_from_dict():
+    command_builder_dict = {HELP: COMMAND_HELP_STRING1}
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_version():
+def case_command_builder_from_dict_with_version():
     version = "7.1.4"
-    json_dict = {HELP: COMMAND_HELP_STRING1, VERSION: version}
+    command_builder_dict = {HELP: COMMAND_HELP_STRING1, VERSION: version}
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_default_args():
-    json_dict = {HELP: COMMAND_HELP_STRING1, ARGS: [ARG1, ARG2]}
+def case_command_builder_from_dict_with_default_args():
+    command_builder_dict = {HELP: COMMAND_HELP_STRING1, ARGS: [ARG1, ARG2]}
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, default_args=[ARG1, ARG2]
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_required_contexts():
-    json_dict = {HELP: COMMAND_HELP_STRING1, REQUIRED_CONTEXTS: [CONTEXT1, CONTEXT2]}
+def case_command_builder_from_dict_with_required_contexts():
+    command_builder_dict = {
+        HELP: COMMAND_HELP_STRING1,
+        REQUIRED_CONTEXTS: [CONTEXT1, CONTEXT2],
+    }
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[CONTEXT1, CONTEXT2]
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_allowed_contexts():
-    json_dict = {HELP: COMMAND_HELP_STRING1, ALLOWED_CONTEXTS: [CONTEXT1, CONTEXT2]}
+def case_command_builder_from_dict_with_allowed_contexts():
+    command_builder_dict = {
+        HELP: COMMAND_HELP_STRING1,
+        ALLOWED_CONTEXTS: [CONTEXT1, CONTEXT2],
+    }
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[CONTEXT1, CONTEXT2]
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_args_override():
-    json_dict = {
+def case_command_builder_from_dict_with_args_override():
+    command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         ARGS: [ARG1, ARG2],
         CONTEXT1: {ARGS: [ARG3, ARG4]},
@@ -95,12 +101,12 @@ def case_command_builder_from_json_with_args_override():
         contexts_specifications={CONTEXT1: ContextSpecification(args=[ARG3, ARG4])},
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_added_args():
-    json_dict = {
+def case_command_builder_from_dict_with_added_args():
+    command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         ARGS: [ARG1, ARG2],
         CONTEXT1: {ADD_ARGS: [ARG3, ARG4]},
@@ -112,12 +118,12 @@ def case_command_builder_from_json_with_added_args():
         contexts_specifications={CONTEXT1: ContextSpecification(add_args=[ARG3, ARG4])},
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_clear_args():
-    json_dict = {
+def case_command_builder_from_dict_with_clear_args():
+    command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         ARGS: [ARG1, ARG2],
         CONTEXT1: {CLEAR_ARGS: True},
@@ -129,12 +135,12 @@ def case_command_builder_from_json_with_clear_args():
         contexts_specifications={CONTEXT1: ContextSpecification(clear_args=True)},
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_two_contexts_specifications():
-    json_dict = {
+def case_command_builder_from_dict_with_two_contexts_specifications():
+    command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         ARGS: [ARG1, ARG2],
         CONTEXT1: {CLEAR_ARGS: True},
@@ -150,13 +156,13 @@ def case_command_builder_from_json_with_two_contexts_specifications():
         },
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @case(tags=[SUCCESSFUL_TAG])
-def case_command_builder_from_json_with_verything():
+def case_command_builder_from_dict_with_verything():
     version = "5.2.6"
-    json_dict = {
+    command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         ARGS: [ARG1, ARG2],
         VERSION: version,
@@ -178,15 +184,17 @@ def case_command_builder_from_json_with_verything():
         },
     )
 
-    return json_dict, command_builder
+    return command_builder_dict, command_builder
 
 
 @parametrize_with_cases(
-    argnames=["json_dict", "command_builder"], cases=THIS_MODULE, has_tag=SUCCESSFUL_TAG
+    argnames=["command_builder_dict", "command_builder"],
+    cases=THIS_MODULE,
+    has_tag=SUCCESSFUL_TAG,
 )
-def test_command_builder_from_json_successful(json_dict, command_builder):
-    actual_builder = CommandBuilder.from_config(
-        command_name=COMMAND1, builder_setups=json_dict
+def test_command_builder_from_dict_successful(command_builder_dict, command_builder):
+    actual_builder = CommandBuilder.from_dict(
+        command_name=COMMAND1, builder_setups=command_builder_dict
     )
     assert actual_builder == command_builder
 
@@ -195,8 +203,8 @@ def test_command_builder_from_json_successful(json_dict, command_builder):
 
 
 @case(tags=[FAILED_TAG])
-def case_command_builder_from_json_fail_on_both_clear_args_and_args():
-    json_dict = {
+def case_command_builder_from_dict_fail_on_both_clear_args_and_args():
+    command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         CONTEXT1: {ARGS: [ARG1, ARG2], CLEAR_ARGS: True},
     }
@@ -205,12 +213,12 @@ def case_command_builder_from_json_fail_on_both_clear_args_and_args():
         f"clear_args and args cannot be both set at the same time"
     )
 
-    return json_dict, error_message
+    return command_builder_dict, error_message
 
 
 @case(tags=[FAILED_TAG])
-def case_command_builder_from_json_fail_on_both_clear_args_and_add_args():
-    json_dict = {
+def case_command_builder_from_dict_fail_on_both_clear_args_and_add_args():
+    command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         CONTEXT1: {ADD_ARGS: [ARG1, ARG2], CLEAR_ARGS: True},
     }
@@ -219,12 +227,12 @@ def case_command_builder_from_json_fail_on_both_clear_args_and_add_args():
         f"clear_args and add_args cannot be both set at the same time"
     )
 
-    return json_dict, error_message
+    return command_builder_dict, error_message
 
 
 @case(tags=[FAILED_TAG])
-def case_command_builder_from_json_fail_on_both_args_and_add_args():
-    json_dict = {
+def case_command_builder_from_dict_fail_on_both_args_and_add_args():
+    command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         CONTEXT1: {ARGS: [ARG1, ARG2], ADD_ARGS: [ARG3, ARG4]},
     }
@@ -233,14 +241,16 @@ def case_command_builder_from_json_fail_on_both_args_and_add_args():
         f"args and add_args cannot be both set at the same time"
     )
 
-    return json_dict, error_message
+    return command_builder_dict, error_message
 
 
 @parametrize_with_cases(
-    argnames=["json_dict", "error_message"],
+    argnames=["command_builder_dict", "error_message"],
     cases=THIS_MODULE,
     has_tag=FAILED_TAG,
 )
-def test_command_builder_build_command_failed(json_dict, error_message):
+def test_command_builder_from_dict_failed(command_builder_dict, error_message):
     with pytest.raises(InconsistentConfiguration, match=f"^{error_message}$"):
-        CommandBuilder.from_config(command_name=COMMAND1, builder_setups=json_dict)
+        CommandBuilder.from_dict(
+            command_name=COMMAND1, builder_setups=command_builder_dict
+        )

--- a/tests/commands_filter/test_commands_filter_as_dict.py
+++ b/tests/commands_filter/test_commands_filter_as_dict.py
@@ -1,0 +1,51 @@
+from pytest_cases import THIS_MODULE, parametrize_with_cases
+
+from statue.commands_filter import CommandsFilter
+from statue.constants import ALLOW_LIST, CONTEXTS, DENY_LIST
+from statue.context import Context
+from tests.constants import (
+    COMMAND1,
+    COMMAND2,
+    COMMAND3,
+    CONTEXT1,
+    CONTEXT2,
+    CONTEXT3,
+    CONTEXT_HELP_STRING1,
+    CONTEXT_HELP_STRING2,
+    CONTEXT_HELP_STRING3,
+)
+
+
+def case_empty_commands_filter():
+    commands_filter = CommandsFilter()
+    filter_dict = {}
+    return commands_filter, filter_dict
+
+
+def case_commands_filter_with_contexts():
+    commands_filter = CommandsFilter(
+        contexts=[
+            Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+            Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+            Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+        ]
+    )
+    filter_dict = {CONTEXTS: [CONTEXT1, CONTEXT2, CONTEXT3]}
+    return commands_filter, filter_dict
+
+
+def case_commands_filter_with_allowed_commands():
+    commands_filter = CommandsFilter(allowed_commands=[COMMAND1, COMMAND2, COMMAND3])
+    filter_dict = {ALLOW_LIST: [COMMAND1, COMMAND2, COMMAND3]}
+    return commands_filter, filter_dict
+
+
+def case_commands_filter_with_denied_commands():
+    commands_filter = CommandsFilter(denied_commands=[COMMAND1, COMMAND2, COMMAND3])
+    filter_dict = {DENY_LIST: [COMMAND1, COMMAND2, COMMAND3]}
+    return commands_filter, filter_dict
+
+
+@parametrize_with_cases(argnames=["commands_filter", "filter_dict"], cases=THIS_MODULE)
+def test_commands_filter_as_dict(commands_filter, filter_dict):
+    assert commands_filter.as_dict() == filter_dict

--- a/tests/configuration/commands_repository/test_commands_repository_basics.py
+++ b/tests/configuration/commands_repository/test_commands_repository_basics.py
@@ -141,6 +141,23 @@ def test_commands_repository_reset():
     assert not commands_repository.has_command(COMMAND2)
 
 
+def test_commands_repository_as_dict():
+    command_builder1, command_builder2, command_builder3 = (
+        command_builder_mock(name=COMMAND1),
+        command_builder_mock(name=COMMAND2),
+        command_builder_mock(name=COMMAND3),
+    )
+    commands_repository = CommandsRepository(
+        command_builder1, command_builder2, command_builder3
+    )
+
+    assert commands_repository.as_dict() == {
+        COMMAND1: command_builder1.as_dict.return_value,
+        COMMAND2: command_builder2.as_dict.return_value,
+        COMMAND3: command_builder3.as_dict.return_value,
+    }
+
+
 def test_commands_repository_get_non_existing_command():
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1),

--- a/tests/configuration/commands_repository/test_commands_repository_update_from_config.py
+++ b/tests/configuration/commands_repository/test_commands_repository_update_from_config.py
@@ -35,10 +35,10 @@ def test_commands_repository_update_adds_new_builder():
     commands_repository = CommandsRepository()
     commands_repository.add_command_builders(command_builder1, command_builder2)
 
-    with mock.patch.object(CommandBuilder, "from_config") as from_config_mock:
-        from_config_mock.return_value = command_builder3
+    with mock.patch.object(CommandBuilder, "from_dict") as from_dict_mock:
+        from_dict_mock.return_value = command_builder3
         commands_repository.update_from_config({COMMAND3: builder_config})
-        from_config_mock.assert_called_once_with(
+        from_dict_mock.assert_called_once_with(
             command_name=COMMAND3, builder_setups=builder_config
         )
 

--- a/tests/configuration/configuration/test_configuration_basics.py
+++ b/tests/configuration/configuration/test_configuration_basics.py
@@ -1,11 +1,33 @@
-from pytest_cases import parametrize
+import pytest
 
+from statue.config.commands_repository import CommandsRepository
 from statue.config.configuration import Configuration
-from statue.constants import HISTORY_SIZE
+from statue.config.contexts_repository import ContextsRepository
+from statue.config.sources_repository import SourcesRepository
+from statue.constants import COMMANDS, CONTEXTS, GENERAL, HISTORY_SIZE, MODE, SOURCES
 from statue.runner import RunnerMode
 
 
-def test_configuration_default_constructor():
+@pytest.fixture
+def mock_contexts_repository_as_dict(mocker):
+    return mocker.patch.object(ContextsRepository, "as_dict")
+
+
+@pytest.fixture
+def mock_commands_repository_as_dict(mocker):
+    return mocker.patch.object(CommandsRepository, "as_dict")
+
+
+@pytest.fixture
+def mock_sources_repository_as_dict(mocker):
+    return mocker.patch.object(SourcesRepository, "as_dict")
+
+
+def test_configuration_default_constructor(
+    mock_contexts_repository_as_dict,
+    mock_commands_repository_as_dict,
+    mock_sources_repository_as_dict,
+):
     configuration = Configuration()
 
     assert configuration.cache.cache_root_directory is None
@@ -14,9 +36,20 @@ def test_configuration_default_constructor():
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0
     assert configuration.default_mode == RunnerMode.SYNC
+    assert configuration.as_dict() == {
+        GENERAL: {MODE: "sync"},
+        CONTEXTS: mock_contexts_repository_as_dict.return_value,
+        COMMANDS: mock_commands_repository_as_dict.return_value,
+        SOURCES: mock_sources_repository_as_dict.return_value,
+    }
 
 
-def test_configuration_constructor_with_cache_dir(tmp_path):
+def test_configuration_constructor_with_cache_dir(
+    mock_contexts_repository_as_dict,
+    mock_commands_repository_as_dict,
+    mock_sources_repository_as_dict,
+    tmp_path,
+):
     cache_dir = tmp_path / "cache"
     configuration = Configuration(cache_root_directory=cache_dir)
 
@@ -26,15 +59,51 @@ def test_configuration_constructor_with_cache_dir(tmp_path):
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0
     assert configuration.default_mode == RunnerMode.SYNC
+    assert configuration.as_dict() == {
+        GENERAL: {MODE: "sync"},
+        CONTEXTS: mock_contexts_repository_as_dict.return_value,
+        COMMANDS: mock_commands_repository_as_dict.return_value,
+        SOURCES: mock_sources_repository_as_dict.return_value,
+    }
 
 
-@parametrize(argnames="mode", argvalues=[RunnerMode.SYNC, RunnerMode.ASYNC])
-def test_configuration_with_default_mode(mode):
-    configuration = Configuration(default_mode=mode)
+def test_configuration_with_sync_default_mode(
+    mock_contexts_repository_as_dict,
+    mock_commands_repository_as_dict,
+    mock_sources_repository_as_dict,
+):
+    configuration = Configuration(default_mode=RunnerMode.SYNC)
 
     assert configuration.cache.cache_root_directory is None
     assert configuration.cache.history_size == HISTORY_SIZE
     assert len(configuration.commands_repository) == 0
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0
-    assert configuration.default_mode == mode
+    assert configuration.default_mode == RunnerMode.SYNC
+    assert configuration.as_dict() == {
+        GENERAL: {MODE: "sync"},
+        CONTEXTS: mock_contexts_repository_as_dict.return_value,
+        COMMANDS: mock_commands_repository_as_dict.return_value,
+        SOURCES: mock_sources_repository_as_dict.return_value,
+    }
+
+
+def test_configuration_with_async_default_mode(
+    mock_contexts_repository_as_dict,
+    mock_commands_repository_as_dict,
+    mock_sources_repository_as_dict,
+):
+    configuration = Configuration(default_mode=RunnerMode.ASYNC)
+
+    assert configuration.cache.cache_root_directory is None
+    assert configuration.cache.history_size == HISTORY_SIZE
+    assert len(configuration.commands_repository) == 0
+    assert len(configuration.contexts_repository) == 0
+    assert len(configuration.sources_repository) == 0
+    assert configuration.default_mode == RunnerMode.ASYNC
+    assert configuration.as_dict() == {
+        GENERAL: {MODE: "async"},
+        CONTEXTS: mock_contexts_repository_as_dict.return_value,
+        COMMANDS: mock_commands_repository_as_dict.return_value,
+        SOURCES: mock_sources_repository_as_dict.return_value,
+    }

--- a/tests/configuration/contexts_repository/test_contexts_repository_basics.py
+++ b/tests/configuration/contexts_repository/test_contexts_repository_basics.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from statue.config.contexts_repository import ContextsRepository
@@ -146,6 +147,18 @@ def test_contexts_repository_iterate():
     contexts_repository = ContextsRepository(context1, context2, context3)
 
     assert list(contexts_repository) == [context1, context2, context3]
+
+
+def test_contexts_repository_as_dict():
+    context1, context2, context3 = (mock.Mock(), mock.Mock(), mock.Mock())
+    context1.name, context2.name, context3.name = CONTEXT1, CONTEXT2, CONTEXT3
+
+    contexts_repository = ContextsRepository(context1, context2, context3)
+    assert contexts_repository.as_dict() == {
+        CONTEXT1: context1.as_dict.return_value,
+        CONTEXT2: context2.as_dict.return_value,
+        CONTEXT3: context3.as_dict.return_value,
+    }
 
 
 def test_contexts_repository_fail_getting_unknown_context():

--- a/tests/configuration/sources_repository/test_sources_repository_basics.py
+++ b/tests/configuration/sources_repository/test_sources_repository_basics.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import mock
+
 from statue.commands_filter import CommandsFilter
 from statue.config.sources_repository import SourcesRepository
 from statue.context import Context
@@ -109,3 +111,17 @@ def test_sources_repository_reset():
 
     assert len(sources_repository) == 0
     assert not sources_repository.sources_list
+
+
+def test_sources_repository_as_dict():
+    filter1, filter2, filter3 = (mock.Mock(), mock.Mock(), mock.Mock())
+    sources_repository = SourcesRepository()
+    sources_repository[Path(SOURCE1)] = filter1
+    sources_repository[Path(SOURCE2)] = filter2
+    sources_repository[Path(SOURCE3)] = filter3
+
+    assert sources_repository.as_dict() == {
+        SOURCE1: filter1.as_dict.return_value,
+        SOURCE2: filter2.as_dict.return_value,
+        SOURCE3: filter3.as_dict.return_value,
+    }

--- a/tests/context/test_context_as_dict.py
+++ b/tests/context/test_context_as_dict.py
@@ -1,0 +1,62 @@
+from pytest_cases import THIS_MODULE, parametrize_with_cases
+
+from statue.constants import ALIASES, ALLOWED_BY_DEFAULT, HELP, PARENT
+from statue.context import Context
+from tests.constants import (
+    CONTEXT1,
+    CONTEXT2,
+    CONTEXT3,
+    CONTEXT4,
+    CONTEXT_HELP_STRING1,
+    CONTEXT_HELP_STRING2,
+)
+
+
+def case_simple_context():
+    context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    context_dict = {HELP: CONTEXT_HELP_STRING1}
+    return context, context_dict
+
+
+def case_aliased_context():
+    context = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, aliases=[CONTEXT2, CONTEXT3]
+    )
+    context_dict = {HELP: CONTEXT_HELP_STRING1, ALIASES: [CONTEXT2, CONTEXT3]}
+    return context, context_dict
+
+
+def case_context_with_parent():
+    parent = Context(CONTEXT2, help=CONTEXT_HELP_STRING2)
+    context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent)
+    context_dict = {HELP: CONTEXT_HELP_STRING1, PARENT: CONTEXT2}
+    return context, context_dict
+
+
+def case_allowed_by_default_context():
+    context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=True)
+    context_dict = {HELP: CONTEXT_HELP_STRING1, ALLOWED_BY_DEFAULT: True}
+    return context, context_dict
+
+
+def case_full_context():
+    parent = Context(CONTEXT2, help=CONTEXT_HELP_STRING2)
+    context = Context(
+        name=CONTEXT1,
+        help=CONTEXT_HELP_STRING1,
+        allowed_by_default=True,
+        parent=parent,
+        aliases=[CONTEXT3, CONTEXT4],
+    )
+    context_dict = {
+        HELP: CONTEXT_HELP_STRING1,
+        ALLOWED_BY_DEFAULT: True,
+        PARENT: CONTEXT2,
+        ALIASES: [CONTEXT3, CONTEXT4],
+    }
+    return context, context_dict
+
+
+@parametrize_with_cases(argnames=["context", "context_dict"], cases=THIS_MODULE)
+def test_context_as_dict(context, context_dict):
+    assert context.as_dict() == context_dict

--- a/tests/evaluation/test_read_write_evaluation.py
+++ b/tests/evaluation/test_read_write_evaluation.py
@@ -207,8 +207,8 @@ def test_evaluation_load_from_file(evaluation_json, evaluation):
 
 
 @parametrize_with_cases(argnames=["evaluation_json", "evaluation"], cases=THIS_MODULE)
-def test_evaluation_as_json(evaluation_json, evaluation):
-    assert evaluation_json == evaluation.as_json()
+def test_evaluation_as_dict(evaluation_json, evaluation):
+    assert evaluation_json == evaluation.as_dict()
 
 
 @parametrize_with_cases(argnames=["evaluation_json", "evaluation"], cases=THIS_MODULE)

--- a/tests/evaluation/test_read_write_evaluation.py
+++ b/tests/evaluation/test_read_write_evaluation.py
@@ -191,8 +191,8 @@ def case_two_sources_two_commands():
 
 
 @parametrize_with_cases(argnames=["evaluation_json", "evaluation"], cases=THIS_MODULE)
-def test_evaluation_from_json(evaluation_json, evaluation):
-    assert evaluation == Evaluation.from_json(evaluation_json)
+def test_evaluation_from_dict(evaluation_json, evaluation):
+    assert evaluation == Evaluation.from_dict(evaluation_json)
 
 
 @parametrize_with_cases(argnames=["evaluation_json", "evaluation"], cases=THIS_MODULE)
@@ -226,6 +226,6 @@ def test_evaluation_save_as_json(evaluation_json, evaluation):
 @parametrize_with_cases(argnames=["evaluation_json", "evaluation"], cases=THIS_MODULE)
 def test_iterate_evaluation(evaluation_json, evaluation):
     for source in evaluation:
-        assert evaluation[source] == SourceEvaluation.from_json(
+        assert evaluation[source] == SourceEvaluation.from_dict(
             evaluation_json["sources_evaluations"][source]
         )

--- a/tests/util.py
+++ b/tests/util.py
@@ -70,6 +70,7 @@ def command_builder_mock(
     command_builder.install = mock.Mock()
     command_builder.update = mock.Mock()
     command_builder.update_to_version = mock.Mock()
+    command_builder.as_dict = mock.Mock()
     return command_builder
 
 


### PR DESCRIPTION
**Description**
One can serialize a `Configuration` object into a complex dictionary.
This dictionary can later be saved as a configuration file.

**Tests**
Add relevant unit tests

**Alternatives**
Not relevant

**Additional context**
Python 3.9, Windows