### PR TITLE
Update config endpoints

### DIFF
--- a/src/statue/cli/config.py
+++ b/src/statue/cli/config.py
@@ -1,4 +1,5 @@
 """Config CLI."""
+# pylint: disable=too-many-arguments
 import sys
 from pathlib import Path
 from typing import Optional, Union
@@ -78,11 +79,26 @@ def show_tree(config: Optional[Union[str, Path]]):
     default=True,
     help="Should use git to trace ignored files",
 )
+@click.option(
+    "--fix-versions",
+    is_flag=True,
+    default=False,
+    help="Fix versions in config when running",
+)
+@click.option(
+    "-i",
+    "--install",
+    is_flag=True,
+    default=False,
+    help="Install latest version for all commands in configuration",
+)
 def init_config_cli(
     config: Optional[Union[str, Path]],
     template: str,
     interactive: bool,
     use_git: bool,
+    fix_versions: bool,
+    install: bool,
 ):
     """
     Initialize configuration for Statue.
@@ -124,6 +140,12 @@ def init_config_cli(
     else:
         for source in sources:
             configuration.sources_repository[source] = CommandsFilter()
+    if fix_versions or install:
+        for command_builder in configuration.commands_repository:
+            if install:
+                command_builder.update()
+            if fix_versions and command_builder.installed():
+                command_builder.set_version_as_installed()
     with open(output_path, mode="w", encoding=ENCODING) as config_file:
         toml.dump(configuration.as_dict(), config_file)
     click.echo("Done!")

--- a/src/statue/cli/config.py
+++ b/src/statue/cli/config.py
@@ -18,7 +18,7 @@ from statue.cli.styled_strings import (
 )
 from statue.commands_filter import CommandsFilter
 from statue.config.configuration_builder import ConfigurationBuilder
-from statue.constants import COMMANDS, ENCODING, VERSION
+from statue.constants import ENCODING
 from statue.exceptions import StatueConfigurationError, UnknownTemplate
 from statue.sources_finder import find_sources
 from statue.templates.templates_provider import TemplatesProvider
@@ -164,22 +164,14 @@ def fixate_commands_versions(
     if len(configuration.commands_repository) == 0:
         click.echo("No commands to fixate.")
         return
-    with open(config, mode="r", encoding=ENCODING) as config_file:
-        raw_config_dict = toml.load(config_file)
-    if COMMANDS not in raw_config_dict:
-        raw_config_dict[COMMANDS] = {}
     for command_builder in configuration.commands_repository:
         if latest:
             command_builder.update(verbosity=verbosity)
         if not command_builder.installed():
             continue
-        if command_builder.name not in raw_config_dict[COMMANDS]:
-            raw_config_dict[COMMANDS][command_builder.name] = {}
-        raw_config_dict[COMMANDS][command_builder.name][
-            VERSION
-        ] = command_builder.installed_version
+        command_builder.set_version_as_installed()
     with open(config, mode="w", encoding=ENCODING) as config_file:
-        toml.dump(raw_config_dict, config_file)
+        toml.dump(configuration.as_dict(), config_file)
 
 
 def __join_names(names_list):

--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -225,6 +225,14 @@ class CommandBuilder:
         """
         return self.installed_version is not None
 
+    def set_version_as_installed(self):
+        """
+        Set version to be the installed version.
+
+        PAY ATTENTION: if command is not installed, version will be set to None
+        """
+        self.version = self.installed_version
+
     def installed_correctly(self) -> bool:
         """
         Checks that command is installed and its version matches.

--- a/tests/cli/config/test_config_fix_versions.py
+++ b/tests/cli/config/test_config_fix_versions.py
@@ -1,34 +1,16 @@
 from unittest import mock
 
 from statue.cli.cli import statue_cli
-from statue.constants import COMMANDS, CONTEXTS, SOURCES, VERSION
-from tests.constants import (
-    COMMAND1,
-    COMMAND2,
-    CONTEXT1,
-    CONTEXT2,
-    CONTEXT3,
-    SOURCE1,
-    SOURCE2,
-)
+from tests.constants import COMMAND1, COMMAND2
 from tests.util import command_builder_mock, dummy_version
-
-
-def build_default_toml():
-    return {
-        SOURCES: {
-            SOURCE1: {CONTEXTS: [CONTEXT1]},
-            SOURCE2: {CONTEXTS: [CONTEXT2, CONTEXT3]},
-        }
-    }
 
 
 def test_config_fix_version_with_no_installed_packages(
     cli_runner,
     mock_build_configuration_from_file,
     mock_cwd,
-    mock_toml_load,
     mock_toml_dump,
+    mock_configuration_as_dict,
 ):
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1, installed=False),
@@ -38,25 +20,25 @@ def test_config_fix_version_with_no_installed_packages(
     configuration.commands_repository.add_command_builders(
         command_builder1, command_builder2
     )
-    mock_toml_load.return_value = build_default_toml()
 
     mock_open = mock.mock_open()
     with mock.patch("statue.cli.config.open", mock_open):
         result = cli_runner.invoke(statue_cli, ["config", "fix-versions"])
-        mock_toml_load.assert_called_once_with(mock_open.return_value)
         mock_toml_dump.assert_called_once_with(
-            {COMMANDS: {}, **build_default_toml()}, mock_open.return_value
+            mock_configuration_as_dict.return_value, mock_open.return_value
         )
 
     assert result.exit_code == 0
+    assert command_builder1.version is None
+    assert command_builder2.version is None
 
 
 def test_config_fix_version_with_one_installed_package(
     cli_runner,
     mock_build_configuration_from_file,
     mock_cwd,
-    mock_toml_load,
     mock_toml_dump,
+    mock_configuration_as_dict,
 ):
     version1 = dummy_version()
     command_builder1, command_builder2 = (
@@ -67,29 +49,26 @@ def test_config_fix_version_with_one_installed_package(
     configuration.commands_repository.add_command_builders(
         command_builder1, command_builder2
     )
-    mock_toml_load.return_value = build_default_toml()
 
     mock_open = mock.mock_open()
     with mock.patch("statue.cli.config.open", mock_open):
         result = cli_runner.invoke(statue_cli, ["config", "fix-versions"])
-        mock_toml_load.assert_called_once_with(mock_open.return_value)
+
         mock_toml_dump.assert_called_once_with(
-            {
-                COMMANDS: {COMMAND1: {VERSION: version1}},
-                **build_default_toml(),
-            },
-            mock_open.return_value,
+            mock_configuration_as_dict.return_value, mock_open.return_value
         )
 
     assert result.exit_code == 0
+    assert command_builder1.version == version1
+    assert command_builder2.version is None
 
 
 def test_config_fix_version_with_two_installed_packages(
     cli_runner,
     mock_build_configuration_from_file,
     mock_cwd,
-    mock_toml_load,
     mock_toml_dump,
+    mock_configuration_as_dict,
 ):
     version1, version2 = dummy_version(), dummy_version()
     command_builder1, command_builder2 = (
@@ -100,37 +79,29 @@ def test_config_fix_version_with_two_installed_packages(
     configuration.commands_repository.add_command_builders(
         command_builder1, command_builder2
     )
-    mock_toml_load.return_value = build_default_toml()
 
     mock_open = mock.mock_open()
     with mock.patch("statue.cli.config.open", mock_open):
         result = cli_runner.invoke(statue_cli, ["config", "fix-versions"])
-        mock_toml_load.assert_called_once_with(mock_open.return_value)
+
         mock_toml_dump.assert_called_once_with(
-            {
-                COMMANDS: {
-                    COMMAND1: {VERSION: version1},
-                    COMMAND2: {VERSION: version2},
-                },
-                **build_default_toml(),
-            },
-            mock_open.return_value,
+            mock_configuration_as_dict.return_value, mock_open.return_value
         )
 
     assert result.exit_code == 0
+    assert command_builder1.version == version1
+    assert command_builder2.version == version2
 
 
 def test_config_fix_version_with_no_commands(
     cli_runner,
     mock_cwd,
-    mock_toml_load,
     mock_toml_dump,
+    mock_configuration_as_dict,
     mock_build_configuration_from_file,
 ):
-    mock_toml_load.return_value = build_default_toml()
-
     result = cli_runner.invoke(statue_cli, ["config", "fix-versions"])
-    mock_toml_load.assert_not_called()
+
     mock_toml_dump.assert_not_called()
 
     assert (
@@ -142,8 +113,8 @@ def test_config_fix_version_latest(
     cli_runner,
     mock_build_configuration_from_file,
     mock_cwd,
-    mock_toml_load,
     mock_toml_dump,
+    mock_configuration_as_dict,
 ):
     version1, version2 = dummy_version(), dummy_version()
     command_builder1, command_builder2 = (
@@ -154,34 +125,28 @@ def test_config_fix_version_latest(
     configuration.commands_repository.add_command_builders(
         command_builder1, command_builder2
     )
-    mock_toml_load.return_value = build_default_toml()
 
     mock_open = mock.mock_open()
     with mock.patch("statue.cli.config.open", mock_open):
         result = cli_runner.invoke(statue_cli, ["config", "fix-versions", "--latest"])
-        mock_toml_load.assert_called_once_with(mock_open.return_value)
+
         mock_toml_dump.assert_called_once_with(
-            {
-                COMMANDS: {
-                    COMMAND1: {VERSION: version1},
-                    COMMAND2: {VERSION: version2},
-                },
-                **build_default_toml(),
-            },
-            mock_open.return_value,
+            mock_configuration_as_dict.return_value, mock_open.return_value
         )
     command_builder1.update.assert_called_once()
     command_builder2.update.assert_called_once()
 
     assert result.exit_code == 0
+    assert command_builder1.version == version1
+    assert command_builder2.version == version2
 
 
 def test_config_fix_version_with_configuration_path(
     cli_runner,
     mock_build_configuration_from_file,
     tmp_path,
-    mock_toml_load,
     mock_toml_dump,
+    mock_configuration_as_dict,
 ):
     config_path = tmp_path / "statue.toml"
     config_path.touch()
@@ -194,21 +159,19 @@ def test_config_fix_version_with_configuration_path(
     configuration.commands_repository.add_command_builders(
         command_builder1, command_builder2
     )
-    mock_toml_load.return_value = build_default_toml()
 
     mock_open = mock.mock_open()
     with mock.patch("statue.cli.config.open", mock_open):
         result = cli_runner.invoke(
             statue_cli, ["config", "fix-versions", "--config", str(config_path)]
         )
-        assert (
-            result.exit_code == 0
-        ), f"Exited with error code and exception: {result.exception}"
-        mock_toml_load.assert_called_once_with(mock_open.return_value)
+
         mock_toml_dump.assert_called_once_with(
-            {
-                COMMANDS: {COMMAND1: {VERSION: version1}},
-                **build_default_toml(),
-            },
-            mock_open.return_value,
+            mock_configuration_as_dict.return_value, mock_open.return_value
         )
+
+    assert (
+        result.exit_code == 0
+    ), f"Exited with error code and exception: {result.exception}"
+    assert command_builder1.version == version1
+    assert command_builder2.version is None

--- a/tests/cli/config/test_config_fix_versions.py
+++ b/tests/cli/config/test_config_fix_versions.py
@@ -10,10 +10,8 @@ from tests.constants import (
     CONTEXT3,
     SOURCE1,
     SOURCE2,
-    VERSION1,
-    VERSION2,
 )
-from tests.util import command_builder_mock
+from tests.util import command_builder_mock, dummy_version
 
 
 def build_default_toml():
@@ -60,7 +58,7 @@ def test_config_fix_version_with_one_installed_package(
     mock_toml_load,
     mock_toml_dump,
 ):
-    version1 = VERSION1
+    version1 = dummy_version()
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1, installed=True, installed_version=version1),
         command_builder_mock(name=COMMAND2, installed=False),
@@ -77,7 +75,7 @@ def test_config_fix_version_with_one_installed_package(
         mock_toml_load.assert_called_once_with(mock_open.return_value)
         mock_toml_dump.assert_called_once_with(
             {
-                COMMANDS: {COMMAND1: {VERSION: VERSION1}},
+                COMMANDS: {COMMAND1: {VERSION: version1}},
                 **build_default_toml(),
             },
             mock_open.return_value,
@@ -93,7 +91,7 @@ def test_config_fix_version_with_two_installed_packages(
     mock_toml_load,
     mock_toml_dump,
 ):
-    version1, version2 = VERSION1, VERSION2
+    version1, version2 = dummy_version(), dummy_version()
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1, installed=True, installed_version=version1),
         command_builder_mock(name=COMMAND2, installed=True, installed_version=version2),
@@ -111,8 +109,8 @@ def test_config_fix_version_with_two_installed_packages(
         mock_toml_dump.assert_called_once_with(
             {
                 COMMANDS: {
-                    COMMAND1: {VERSION: VERSION1},
-                    COMMAND2: {VERSION: VERSION2},
+                    COMMAND1: {VERSION: version1},
+                    COMMAND2: {VERSION: version2},
                 },
                 **build_default_toml(),
             },
@@ -147,7 +145,7 @@ def test_config_fix_version_latest(
     mock_toml_load,
     mock_toml_dump,
 ):
-    version1, version2 = VERSION1, VERSION2
+    version1, version2 = dummy_version(), dummy_version()
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1, installed=True, installed_version=version1),
         command_builder_mock(name=COMMAND2, installed=True, installed_version=version2),
@@ -165,8 +163,8 @@ def test_config_fix_version_latest(
         mock_toml_dump.assert_called_once_with(
             {
                 COMMANDS: {
-                    COMMAND1: {VERSION: VERSION1},
-                    COMMAND2: {VERSION: VERSION2},
+                    COMMAND1: {VERSION: version1},
+                    COMMAND2: {VERSION: version2},
                 },
                 **build_default_toml(),
             },
@@ -187,7 +185,7 @@ def test_config_fix_version_with_configuration_path(
 ):
     config_path = tmp_path / "statue.toml"
     config_path.touch()
-    version1 = VERSION1
+    version1 = dummy_version()
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1, installed=True, installed_version=version1),
         command_builder_mock(name=COMMAND2, installed=False),
@@ -209,7 +207,7 @@ def test_config_fix_version_with_configuration_path(
         mock_toml_load.assert_called_once_with(mock_open.return_value)
         mock_toml_dump.assert_called_once_with(
             {
-                COMMANDS: {COMMAND1: {VERSION: VERSION1}},
+                COMMANDS: {COMMAND1: {VERSION: version1}},
                 **build_default_toml(),
             },
             mock_open.return_value,

--- a/tests/command_builder/test_command_builder_basics.py
+++ b/tests/command_builder/test_command_builder_basics.py
@@ -13,6 +13,7 @@ from tests.constants import (
     CONTEXT5,
     CONTEXT6,
 )
+from tests.util import dummy_version
 
 
 def test_command_builder_empty_constructor():
@@ -31,7 +32,7 @@ def test_command_builder_empty_constructor():
 
 
 def test_command_builder_with_version():
-    version = "6.5.2"
+    version = dummy_version()
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
     )
@@ -133,7 +134,7 @@ def test_command_builder_with_all_fields():
         ContextSpecification(args=[ARG3]),
         ContextSpecification(add_args=[ARG4]),
     )
-    version = "4.5.1"
+    version = dummy_version()
     command_builder = CommandBuilder(
         name=COMMAND1,
         help=COMMAND_HELP_STRING1,

--- a/tests/command_builder/test_command_builder_build_command.py
+++ b/tests/command_builder/test_command_builder_build_command.py
@@ -25,6 +25,7 @@ from tests.constants import (
 )
 
 # Successful tests
+from tests.util import dummy_version
 
 
 @case(tags=SUCCESSFUL_TAG)
@@ -49,7 +50,7 @@ def case_command_builder_with_default_args():
 
 @case(tags=SUCCESSFUL_TAG)
 def case_command_builder_with_version():
-    version = "1.2.3"
+    version = dummy_version()
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
     )

--- a/tests/command_builder/test_command_builder_dict_encoding.py
+++ b/tests/command_builder/test_command_builder_dict_encoding.py
@@ -30,6 +30,7 @@ from tests.constants import (
 )
 
 # Successful tests
+from tests.util import dummy_version
 
 
 @case(tags=[SUCCESSFUL_TAG])
@@ -42,7 +43,7 @@ def case_simple_command_builder_from_dict():
 
 @case(tags=[SUCCESSFUL_TAG])
 def case_command_builder_from_dict_with_version():
-    version = "7.1.4"
+    version = dummy_version()
     command_builder_dict = {HELP: COMMAND_HELP_STRING1, VERSION: version}
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
@@ -161,7 +162,7 @@ def case_command_builder_from_dict_with_two_contexts_specifications():
 
 @case(tags=[SUCCESSFUL_TAG])
 def case_command_builder_from_dict_with_verything():
-    version = "5.2.6"
+    version = dummy_version()
     command_builder_dict = {
         HELP: COMMAND_HELP_STRING1,
         ARGS: [ARG1, ARG2],

--- a/tests/command_builder/test_command_builder_install.py
+++ b/tests/command_builder/test_command_builder_install.py
@@ -3,12 +3,13 @@ import sys
 from statue.command_builder import CommandBuilder
 from statue.verbosity import SILENT
 from tests.constants import COMMAND1, COMMAND_HELP_STRING1
+from tests.util import dummy_version
 
 
 def test_command_builder_wont_install_if_already_installed(
     mock_get_package, mock_subprocess
 ):
-    version = "6.2.1"
+    version = dummy_version()
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
@@ -50,7 +51,7 @@ def test_command_builder_install_silently(mock_get_package, mock_subprocess, env
 def test_command_builder_install_specified_version(
     mock_get_package, mock_subprocess, environ
 ):
-    version = "4.2.1"
+    version = dummy_version()
     mock_get_package.return_value = None
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version

--- a/tests/command_builder/test_command_builder_is_installed.py
+++ b/tests/command_builder/test_command_builder_is_installed.py
@@ -7,6 +7,7 @@ def test_command_builder_not_installed(mock_get_package):
     mock_get_package.return_value = None
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
+    assert command_builder.version is None
     assert command_builder.installed_version is None
     assert not command_builder.installed()
     assert command_builder.installed_version_match()
@@ -18,6 +19,7 @@ def test_command_builder_is_installed_without_specified_version(mock_get_package
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
+    assert command_builder.version is None
     assert command_builder.installed_version == version
     assert command_builder.installed()
     assert command_builder.installed_version_match()
@@ -31,6 +33,7 @@ def test_command_builder_is_installed_correctly(mock_get_package):
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
     )
 
+    assert command_builder.version == version
     assert command_builder.installed_version == version
     assert command_builder.installed()
     assert command_builder.installed_version_match()
@@ -44,7 +47,23 @@ def test_command_builder_is_installed_incorrectly(mock_get_package):
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
     )
 
+    assert command_builder.version == version
     assert command_builder.installed_version == installed_version
     assert command_builder.installed()
     assert not command_builder.installed_version_match()
     assert not command_builder.installed_correctly()
+
+
+def test_command_builder_set_version_as_installed(mock_get_package):
+    version, installed_version = dummy_version(), dummy_version()
+    mock_get_package.return_value.version = installed_version
+    command_builder = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
+    )
+    command_builder.set_version_as_installed()
+
+    assert command_builder.version == installed_version
+    assert command_builder.installed_version == installed_version
+    assert command_builder.installed()
+    assert command_builder.installed_version_match()
+    assert command_builder.installed_correctly()

--- a/tests/command_builder/test_command_builder_is_installed.py
+++ b/tests/command_builder/test_command_builder_is_installed.py
@@ -1,5 +1,6 @@
 from statue.command_builder import CommandBuilder
 from tests.constants import COMMAND1, COMMAND_HELP_STRING1
+from tests.util import dummy_version
 
 
 def test_command_builder_not_installed(mock_get_package):
@@ -13,7 +14,7 @@ def test_command_builder_not_installed(mock_get_package):
 
 
 def test_command_builder_is_installed_without_specified_version(mock_get_package):
-    version = "6.2.1"
+    version = dummy_version()
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
@@ -24,7 +25,7 @@ def test_command_builder_is_installed_without_specified_version(mock_get_package
 
 
 def test_command_builder_is_installed_correctly(mock_get_package):
-    version = "6.2.1"
+    version = dummy_version()
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
@@ -37,7 +38,7 @@ def test_command_builder_is_installed_correctly(mock_get_package):
 
 
 def test_command_builder_is_installed_incorrectly(mock_get_package):
-    version, installed_version = "6.2.1", "5.8.1"
+    version, installed_version = dummy_version(), dummy_version()
     mock_get_package.return_value.version = installed_version
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version

--- a/tests/command_builder/test_command_builder_uninstall.py
+++ b/tests/command_builder/test_command_builder_uninstall.py
@@ -3,10 +3,11 @@ import sys
 from statue.command_builder import CommandBuilder
 from statue.verbosity import SILENT
 from tests.constants import COMMAND1, COMMAND_HELP_STRING1
+from tests.util import dummy_version
 
 
 def test_command_builder_uninstall(mock_get_package, mock_subprocess, environ):
-    version = "6.2.1"
+    version = dummy_version()
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
@@ -32,7 +33,7 @@ def test_command_builder_uninstall_if_not_already_uninstalled(
 
 
 def test_command_builder_uninstall_silently(mock_get_package, mock_subprocess, environ):
-    version = "6.2.1"
+    version = dummy_version()
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
@@ -49,7 +50,7 @@ def test_command_builder_uninstall_silently(mock_get_package, mock_subprocess, e
 def test_command_builder_uninstall_specified_version(
     mock_get_package, mock_subprocess, environ
 ):
-    version, installed_version = "4.2.1", "6.2.1"
+    version, installed_version = dummy_version(), dummy_version()
     mock_get_package.return_value.version = installed_version
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version

--- a/tests/command_builder/test_command_builder_update.py
+++ b/tests/command_builder/test_command_builder_update.py
@@ -3,6 +3,7 @@ import sys
 from statue.command_builder import CommandBuilder
 from statue.verbosity import SILENT
 from tests.constants import COMMAND1, COMMAND_HELP_STRING1
+from tests.util import dummy_version
 
 
 def test_command_builder_update(mock_get_package, mock_subprocess, environ):
@@ -22,7 +23,7 @@ def test_command_builder_update(mock_get_package, mock_subprocess, environ):
 def test_command_builder_will_update_even_if_already_installed(
     mock_get_package, mock_subprocess, environ
 ):
-    version = "6.2.1"
+    version = dummy_version()
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
@@ -53,7 +54,7 @@ def test_command_builder_update_silently(mock_get_package, mock_subprocess, envi
 def test_command_builder_update_to_latest_even_if_version_is_specified(
     mock_get_package, mock_subprocess, environ
 ):
-    version = "4.2.1"
+    version = dummy_version()
     mock_get_package.return_value = None
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version

--- a/tests/command_builder/test_command_builder_update_from_config.py
+++ b/tests/command_builder/test_command_builder_update_from_config.py
@@ -29,11 +29,12 @@ from tests.constants import (
 )
 
 # Successful tests
+from tests.util import dummy_version
 
 
 @case(tags=SUCCESSFUL_TAG)
 def case_command_builder_update_from_config_with_nothing():
-    version = "1.3.4"
+    version = dummy_version()
     command_builder = CommandBuilder(
         name=COMMAND1,
         help=COMMAND_HELP_STRING1,
@@ -65,7 +66,7 @@ def case_command_builder_update_from_config_with_nothing():
 
 @case(tags=SUCCESSFUL_TAG)
 def case_command_builder_update_from_config_version():
-    old_version, new_version = "1.3.4", "1.3.5"
+    old_version, new_version = dummy_version(), dummy_version()
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=old_version
     )

--- a/tests/command_builder/test_command_builder_update_to_version.py
+++ b/tests/command_builder/test_command_builder_update_to_version.py
@@ -4,6 +4,7 @@ from unittest import mock
 from statue.command_builder import CommandBuilder
 from statue.verbosity import SILENT
 from tests.constants import COMMAND1, COMMAND_HELP_STRING1
+from tests.util import dummy_version
 
 
 def test_command_builder_update_to_version(mock_get_package, mock_subprocess, environ):
@@ -23,7 +24,7 @@ def test_command_builder_update_to_version(mock_get_package, mock_subprocess, en
 def test_command_builder_will_update_to_version_even_if_already_installed(
     mock_get_package, mock_subprocess, environ
 ):
-    version = "6.2.1"
+    version = dummy_version()
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
 
@@ -56,7 +57,7 @@ def test_command_builder_update_to_version_silently(
 def test_command_builder_update_to_specific_version_when_not_already_installed(
     mock_get_package, mock_subprocess, environ
 ):
-    version = "4.2.1"
+    version = dummy_version()
     mock_get_package.return_value = None
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
@@ -75,7 +76,7 @@ def test_command_builder_update_to_specific_version_when_not_already_installed(
 def test_command_builder_update_to_specific_version_when_installed_version_match(
     mock_get_package, mock_subprocess, environ
 ):
-    version = "4.2.1"
+    version = dummy_version()
     mock_get_package.return_value.version = version
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
@@ -89,7 +90,7 @@ def test_command_builder_update_to_specific_version_when_installed_version_match
 def test_command_builder_update_to_specific_version_when_already_installed(
     mock_subprocess, environ
 ):
-    version, installed_version = "6.2.1", "4.2.1"
+    version, installed_version = dummy_version(), dummy_version()
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
     )

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -35,7 +35,6 @@ COMMAND4, COMMAND_HELP_STRING4, COMMAND_CAPTURED_OUTPUT4 = command_strings("comm
 COMMAND5, COMMAND_HELP_STRING5, COMMAND_CAPTURED_OUTPUT5 = command_strings("command5")
 COMMAND6, COMMAND_HELP_STRING6, COMMAND_CAPTURED_OUTPUT6 = command_strings("command6")
 ARG1, ARG2, ARG3, ARG4, ARG5, ARG6 = "arg1", "arg2", "arg3", "arg4", "arg5", "arg6"
-VERSION1, VERSION2 = "version1", "version2"
 CONTEXT1, CONTEXT_HELP_STRING1 = name_and_help_string("context1")
 CONTEXT2, CONTEXT_HELP_STRING2 = name_and_help_string("context2")
 CONTEXT3, CONTEXT_HELP_STRING3 = name_and_help_string("context3")

--- a/tests/util.py
+++ b/tests/util.py
@@ -9,6 +9,15 @@ from statue.evaluation import Evaluation, SourceEvaluation
 from tests.constants import EPSILON
 
 
+def dummy_version():
+    major, minor, patch = (
+        random.randint(0, 10),
+        random.randint(0, 10),
+        random.randint(0, 10),
+    )
+    return f"{major}.{minor}.{patch}"
+
+
 def build_commands_builders_map(*commands_builders: CommandBuilder):
     return {
         commands_builders.name: commands_builders


### PR DESCRIPTION
**Description**
Updated the `config` endpoints:
* `fix-version` now use `Configuration.as_dict()` instead of writing manually
* `init` can install and fix versions

**Tests**
Added unit tests

**Alternatives**
Not relevant

**Additional context**
Python 3.9