### PR TITLE
Use tqdm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     importlib_resources>=5.4.0;python_version<'3.9'
     toml >= 0.10.2
     click >= 8.0.1
+    tqdm >= 4.63.0
     GitPython >= 3.1.27
     types-toml >= 0.10.4
     types-setuptools >= 57.4.10

--- a/src/statue/cli/run.py
+++ b/src/statue/cli/run.py
@@ -15,12 +15,7 @@ from statue.cli.common_flags import (
     verbosity_option,
 )
 from statue.cli.string_util import boxed_string, evaluation_string
-from statue.cli.styled_strings import (
-    failure_style,
-    name_style,
-    source_style,
-    success_style,
-)
+from statue.cli.styled_strings import failure_style, name_style, source_style
 from statue.commands_filter import CommandsFilter
 from statue.config.configuration import Configuration
 from statue.evaluation import Evaluation
@@ -153,13 +148,7 @@ def run_cli(  # pylint: disable=too-many-arguments
     if is_verbose(verbosity):
         click.echo(f"Running evaluation in {mode.lower()} mode")
     runner = build_runner(mode)
-    with click.progressbar(
-        length=commands_map.total_commands_count, show_pos=True, show_eta=False
-    ) as bar:
-        evaluation = runner.evaluate(
-            commands_map=commands_map,
-            update_func=lambda command: __bar_update_func(bar, command),
-        )
+    evaluation = runner.evaluate(commands_map)
     if not is_silent(verbosity):
         click.echo(boxed_string("Evaluation"))
         click.echo(evaluation_string(evaluation, verbosity=verbosity))
@@ -251,13 +240,3 @@ def __handle_missing_commands(ctx, missing_commands, install, verbosity):
                 "commands before running"
             )
             ctx.exit(1)
-
-
-def __bar_update_func(bar, partial_evaluation: Evaluation):
-    bar.update(1)
-
-    failures = failure_style(f"{partial_evaluation.failed_commands_number} failed")
-    success = success_style(
-        f"{partial_evaluation.successful_commands_number} succeeded"
-    )
-    bar.label = f"{failures}, {success}"

--- a/src/statue/constants.py
+++ b/src/statue/constants.py
@@ -25,3 +25,6 @@ VERSION = "version"
 MODE = "mode"
 
 DATETIME_FORMAT = "%m/%d/%Y, %H:%M:%S"
+BAR_FORMAT = "{l_bar}{bar}| {n_fmt}/{total_fmt}"
+MAIN_BAR_COLOR = "blue"
+SECONDARY_BAR_COLOR = "yellow"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,14 +32,13 @@ def mock_toml_dump(mocker):
 
 
 @pytest.fixture
-def mock_subprocess(mocker):
-    return mocker.patch("subprocess.run")
+def mock_tqdm(mocker):
+    return mocker.patch("tqdm.tqdm")
 
 
 @pytest.fixture
-def environ(monkeypatch):
-    monkeypatch.setattr(os, "environ", ENVIRON)
-    return ENVIRON
+def mock_tqdm_range(mocker):
+    return mocker.patch("tqdm.trange")
 
 
 # Configuration Mocks
@@ -137,3 +136,14 @@ def mock_evaluation_save_as_json(mocker):
 @pytest.fixture
 def print_mock(mocker):
     return mocker.patch("builtins.print")
+
+
+@pytest.fixture
+def mock_subprocess(mocker):
+    return mocker.patch("subprocess.run")
+
+
+@pytest.fixture
+def environ(monkeypatch):
+    monkeypatch.setattr(os, "environ", ENVIRON)
+    return ENVIRON


### PR DESCRIPTION
**Description**
Use `tqdm` instead of `click.progressbar`

Fixes #123

**Tests**
Fixed relevant unit tests.

**Alternatives**
Keep using `click.progressbar`.
This feature is no longer supported by `click`.

**Additional context**
Python 3.9, Windows