### PR TITLE
click command options returns `pathlib.Path` instead of `str`

### DIFF
--- a/src/statue/cli/cli.py
+++ b/src/statue/cli/cli.py
@@ -1,6 +1,6 @@
 """Main CLI for statue."""
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import click
 
@@ -20,23 +20,21 @@ pass_configuration = click.make_pass_decorator(Configuration)
 @click.option(
     "--cache-dir",
     envvar="STATUE_CACHE",
-    type=click.Path(exists=True, file_okay=False),
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Statue caching directory path",
 )
 @click.pass_context
 def statue_cli(
     ctx: click.Context,
-    config: Optional[Union[str, Path]],
-    cache_dir: Optional[Union[str, Path]],
+    config: Optional[Path],
+    cache_dir: Optional[Path],
 ):
     """Statue is a static code analysis tools orchestrator."""
     if ctx.invoked_subcommand in ["config", "templates"]:
         return
-    config_path = Path(config) if config is not None else None
-    cache_dir = Path(cache_dir) if cache_dir is not None else None
     try:
         ctx.obj = ConfigurationBuilder.build_configuration_from_file(
-            statue_configuration_path=config_path, cache_dir=cache_dir
+            statue_configuration_path=config, cache_dir=cache_dir
         )
     except StatueConfigurationError as error:
         click.echo(failure_style(click.style(error)))

--- a/src/statue/cli/common_flags.py
+++ b/src/statue/cli/common_flags.py
@@ -1,4 +1,6 @@
 """Common flags used by multiple CLIs."""
+from pathlib import Path
+
 import click
 
 from statue.verbosity import DEFAULT_VERBOSITY, SILENT, VERBOSE, VERBOSITIES
@@ -6,7 +8,7 @@ from statue.verbosity import DEFAULT_VERBOSITY, SILENT, VERBOSE, VERBOSITIES
 config_path_option = click.option(
     "--config",
     envvar="STATUE_CONFIG",
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
     help="Statue configuration file.",
 )
 contexts_option = click.option(

--- a/src/statue/cli/config/config_commands.py
+++ b/src/statue/cli/config/config_commands.py
@@ -1,6 +1,6 @@
 """Commands configuration CLI."""
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import click
 import tomli_w
@@ -24,7 +24,7 @@ from statue.config.configuration_builder import ConfigurationBuilder
 )
 @verbose_option
 def fixate_commands_versions_cli(
-    config: Optional[Union[str, Path]],
+    config: Optional[Path],
     latest: bool,
     verbosity: str,
 ):
@@ -34,11 +34,8 @@ def fixate_commands_versions_cli(
     This helps you make sure that you use the same checkers in all commands
     across time.
     """
-    config = (
-        Path(config)
-        if config is not None
-        else ConfigurationBuilder.configuration_path()
-    )
+    if config is None:
+        config = ConfigurationBuilder.configuration_path()
     configuration = ConfigurationBuilder.build_configuration_from_file(config)
     if len(configuration.commands_repository) == 0:
         click.echo("No commands to fixate.")

--- a/src/statue/cli/config/config_init.py
+++ b/src/statue/cli/config/config_init.py
@@ -1,7 +1,7 @@
 """Initialize configuration CLI."""
 import sys
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import click
 import git
@@ -49,7 +49,7 @@ from statue.templates.templates_provider import TemplatesProvider
     help="Install latest version for all commands in configuration",
 )
 def init_config_cli(  # pylint: disable=too-many-arguments
-    config: Optional[Union[str, Path]],
+    config: Optional[Path],
     template: str,
     interactive: bool,
     use_git: bool,
@@ -73,9 +73,7 @@ def init_config_cli(  # pylint: disable=too-many-arguments
         click.echo(failure_style(str(error)))
         sys.exit(3)
     output_path = (
-        Path(config)
-        if config is not None
-        else ConfigurationBuilder.configuration_path()
+        config if config is not None else ConfigurationBuilder.configuration_path()
     )
     directory = Path.cwd()
     repo = None

--- a/src/statue/cli/config/config_show.py
+++ b/src/statue/cli/config/config_show.py
@@ -1,6 +1,6 @@
 """Show configuration CLI."""
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import click
 
@@ -13,13 +13,10 @@ from statue.constants import ENCODING
 
 @config_cli.command("show")
 @config_path_option
-def show_config_cli(config: Optional[Union[str, Path]]):
+def show_config_cli(config: Optional[Path]):
     """Show configuration file context."""
-    config = (
-        Path(config)
-        if config is not None
-        else ConfigurationBuilder.configuration_path()
-    )
+    if config is None:
+        config = ConfigurationBuilder.configuration_path()
     with open(config, mode="r", encoding=ENCODING) as config_file:
         lines = config_file.readlines()
     click.echo_via_pager(lines)
@@ -27,14 +24,13 @@ def show_config_cli(config: Optional[Union[str, Path]]):
 
 @config_cli.command("show-tree")
 @config_path_option
-def show_config_tree_cli(config: Optional[Union[str, Path]]):
+def show_config_tree_cli(config: Optional[Path]):
     """
     Show sources configuration as a tree.
 
     This method prints the sources' configuration as a tree, including:
     contexts, allow and deny lists and matching commands.
     """
-    config = Path(config) if config is not None else None
     configuration = ConfigurationBuilder.build_configuration_from_file(config)
     sources_list = configuration.sources_repository.sources_list
     if len(sources_list) == 0:

--- a/src/statue/cli/run.py
+++ b/src/statue/cli/run.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-locals
 """Run CLI."""
 from pathlib import Path
-from typing import List, Optional, Sequence, Union
+from typing import List, Optional, Sequence
 
 import click
 
@@ -25,7 +25,7 @@ from statue.verbosity import is_silent, is_verbose
 
 
 @statue_cli.command("run")
-@click.argument("sources", nargs=-1)
+@click.argument("sources", type=click.Path(exists=True, path_type=Path), nargs=-1)
 @contexts_option
 @allow_option
 @deny_option
@@ -75,7 +75,7 @@ from statue.verbosity import is_silent, is_verbose
 @click.option(
     "-o",
     "--output",
-    type=click.Path(dir_okay=False),
+    type=click.Path(dir_okay=False, path_type=Path),
     help="Output path to save evaluation result",
 )
 @click.pass_context
@@ -83,7 +83,7 @@ from statue.verbosity import is_silent, is_verbose
 def run_cli(  # pylint: disable=too-many-arguments
     configuration: Configuration,
     ctx: click.Context,
-    sources: Sequence[Union[Path, str]],
+    sources: Sequence[Path],
     context: Optional[List[str]],
     allow: Optional[List[str]],
     deny: Optional[List[str]],
@@ -93,7 +93,7 @@ def run_cli(  # pylint: disable=too-many-arguments
     cache: bool,
     verbosity: str,
     mode: Optional[str],
-    output: Optional[str],
+    output: Optional[Path],
 ) -> None:
     """
     Run static code analysis commands on sources.
@@ -163,10 +163,10 @@ def run_cli(  # pylint: disable=too-many-arguments
     ctx.exit(__print_evaluation_and_return_exit_code(evaluation))
 
 
-def __get_sources(sources, configuration):
+def __get_sources(sources: Sequence[Path], configuration: Configuration) -> List[Path]:
     if len(sources) == 0:
         return configuration.sources_repository.sources_list
-    return [Path(source) for source in sources]
+    return list(sources)
 
 
 def __print_evaluation_and_return_exit_code(evaluation: Evaluation):

--- a/src/statue/command.py
+++ b/src/statue/command.py
@@ -6,7 +6,7 @@ import subprocess  # nosec
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from statue.constants import ENCODING
 from statue.exceptions import CommandExecutionError
@@ -71,18 +71,18 @@ class Command:
     name: str
     args: List[str] = field(default_factory=list)
 
-    def program_execution_args(self, source: Union[Path, str]) -> List[str]:
+    def program_execution_args(self, source: Path) -> List[str]:
         """
         Get the program command to be run as a subprocess.
 
         :param source: The source to run the command on.
-        :type source: Union[Path, str]
+        :type source: Path
         :return: Program arguments list
         :rtype: List[str]
         """
         return [self.name, str(source), *self.args]
 
-    def execute(self, source: str) -> CommandEvaluation:
+    def execute(self, source: Path) -> CommandEvaluation:
         """
         Execute the command.
 

--- a/src/statue/config/configuration.py
+++ b/src/statue/config/configuration.py
@@ -56,7 +56,7 @@ class Configuration:
                 CommandsFilter.merge(commands_filter, self.sources_repository[source])
             )
             if len(commands) != 0:
-                commands_map[str(source)] = commands
+                commands_map[source] = commands
         return commands_map
 
     def build_commands(self, commands_filter: CommandsFilter) -> List[Command]:

--- a/src/statue/evaluation.py
+++ b/src/statue/evaluation.py
@@ -130,41 +130,41 @@ class SourceEvaluation:
 class Evaluation:
     """Full evaluation class."""
 
-    sources_evaluations: Dict[str, SourceEvaluation] = field(default_factory=dict)
+    sources_evaluations: Dict[Path, SourceEvaluation] = field(default_factory=dict)
     total_execution_duration: float = field(default=0)
 
-    def __iter__(self) -> Iterator[str]:
+    def __iter__(self) -> Iterator[Path]:
         """
         Iterate over evaluation.
 
         :return: self iterator
-        :rtype: Iterator[str]
+        :rtype: Iterator[Path]
         """
         return iter(self.sources_evaluations)
 
-    def __getitem__(self, item: str) -> SourceEvaluation:
+    def __getitem__(self, item: Path) -> SourceEvaluation:
         """
         Get source evaluation.
 
         :param item: Source name
-        :type item: str
+        :type item: Path
         :return: Source's evaluation
         :rtype: SourceEvaluation
         """
         return self.sources_evaluations[item]
 
-    def __setitem__(self, key: str, value: SourceEvaluation) -> None:
+    def __setitem__(self, key: Path, value: SourceEvaluation) -> None:
         """
         Set source evaluation.
 
         :param key: Source name
-        :type key: str
+        :type key: Path
         :param value: Source's evaluation
         :type value: SourceEvaluation
         """
         self.sources_evaluations[key] = value
 
-    def keys(self) -> KeysView[str]:
+    def keys(self) -> KeysView[Path]:
         """
         Get sources as generator.
 
@@ -182,7 +182,7 @@ class Evaluation:
         """
         return self.sources_evaluations.values()
 
-    def items(self) -> ItemsView[str, SourceEvaluation]:
+    def items(self) -> ItemsView[Path, SourceEvaluation]:
         """
         Get sources evaluations.
 
@@ -335,7 +335,7 @@ class Evaluation:
         """
         return Evaluation(
             sources_evaluations={
-                input_path: SourceEvaluation.from_dict(source_evaluation)
+                Path(input_path): SourceEvaluation.from_dict(source_evaluation)
                 for input_path, source_evaluation in evaluation[
                     "sources_evaluations"
                 ].items()

--- a/src/statue/evaluation.py
+++ b/src/statue/evaluation.py
@@ -2,7 +2,7 @@
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, ItemsView, Iterator, KeysView, List, Union, ValuesView
+from typing import Any, Dict, ItemsView, Iterator, KeysView, List, ValuesView
 
 from statue.command import CommandEvaluation
 from statue.commands_map import CommandsMap
@@ -198,18 +198,18 @@ class Evaluation:
         :return: Self as dictionary
         :rtype: Dict[str, List[Dict[str, Any]]]
         """
-        sources_evaluations = {key: value.as_dict() for key, value in self.items()}
+        sources_evaluations = {str(key): value.as_dict() for key, value in self.items()}
         return dict(
             sources_evaluations=sources_evaluations,
             total_execution_duration=self.total_execution_duration,
         )
 
-    def save_as_json(self, output: Union[Path, str]) -> None:
+    def save_as_json(self, output: Path) -> None:
         """
         Save evaluation as json.
 
         :param output: Path to save self in
-        :type output: Path or str
+        :type output: Path
         """
         with open(output, mode="w", encoding=ENCODING) as output_file:
             json.dump(self.as_dict(), output_file, indent=2)

--- a/src/statue/runner.py
+++ b/src/statue/runner.py
@@ -72,7 +72,7 @@ class SynchronousEvaluationRunner(  # pylint: disable=too-few-public-methods
                     bar_format=BAR_FORMAT,
                     colour=SECONDARY_BAR_COLOR,
                     leave=False,
-                    desc=source,
+                    desc=str(source),
                 ):
                     evaluation[source].append(command.execute(source))
                     main_bar.update(1)

--- a/src/statue/runner.py
+++ b/src/statue/runner.py
@@ -3,6 +3,7 @@ import abc
 import asyncio
 import time
 from enum import Enum, auto
+from pathlib import Path
 from typing import List
 
 import tqdm
@@ -119,7 +120,9 @@ class AsynchronousEvaluationRunner(EvaluationRunner):
         """
         evaluation = Evaluation()
         start_time = time.time()
-        max_source_name_length = max([len(source) for source in commands_map.keys()])
+        max_source_name_length = max(
+            [len(source.as_posix()) for source in commands_map.keys()]
+        )
         with tqdm.trange(
             commands_map.total_commands_count,
             bar_format=BAR_FORMAT,
@@ -143,7 +146,7 @@ class AsynchronousEvaluationRunner(EvaluationRunner):
 
     async def evaluate_source(  # pylint: disable=too-many-arguments
         self,
-        source: str,
+        source: Path,
         commands: List[Command],
         evaluation: Evaluation,
         main_bar: tqdm.tqdm,
@@ -156,7 +159,7 @@ class AsynchronousEvaluationRunner(EvaluationRunner):
         :param source_bar_pos: Position of the source bar to print
         :type source_bar_pos: int
         :param source: Path of the desired source.
-        :type source: str
+        :type source: Path
         :param commands: List of commands to run on the source.
         :type commands: List[Command]
         :param evaluation: Evaluation instance to be updated after commands are running.
@@ -174,7 +177,7 @@ class AsynchronousEvaluationRunner(EvaluationRunner):
             position=source_bar_pos,
             leave=False,
             colour=SECONDARY_BAR_COLOR,
-            desc=f"{source:{max_source_name_length}}",
+            desc=f"{source.as_posix():{max_source_name_length}}",
         ) as source_bar:
             coros = [
                 self.evaluate_command(
@@ -195,7 +198,7 @@ class AsynchronousEvaluationRunner(EvaluationRunner):
     async def evaluate_command(  # pylint: disable=too-many-arguments
         self,
         command: Command,
-        source: str,
+        source: Path,
         evaluation: Evaluation,
         source_bar: tqdm.tqdm,
         main_bar: tqdm.tqdm,
@@ -204,7 +207,7 @@ class AsynchronousEvaluationRunner(EvaluationRunner):
         Evaluate command on source and return command evaluation report.
 
         :param source: Path of the desired source.
-        :type source: str
+        :type source: Path
         :param command: Command to run on the source.
         :type command: Command
         :param evaluation: Evaluation instance to be updated after commands are running.

--- a/tests/cli/test_run_cli.py
+++ b/tests/cli/test_run_cli.py
@@ -175,7 +175,7 @@ def test_run_and_save_to_file(
     configuration.cache.save_evaluation.assert_called_once()
     assert_evaluation_was_printed(result, mock_evaluation_string)
 
-    mock_evaluation_save_as_json.assert_called_once_with(str(output_path))
+    mock_evaluation_save_as_json.assert_called_once_with(output_path)
 
 
 def test_run_over_recent_commands(
@@ -461,18 +461,20 @@ def test_run_on_given_source(
     mock_build_configuration_from_file,
     mock_cwd,
     mock_evaluation_string,
+    tmp_path,
 ):
     configuration = mock_build_configuration_from_file.return_value
     configuration.build_commands_map.return_value = build_commands_map()
-
-    result = cli_runner.invoke(statue_cli, ["run", SOURCE1])
+    source = tmp_path / SOURCE1
+    source.touch()
+    result = cli_runner.invoke(statue_cli, ["run", str(source)])
 
     assert (
         result.exit_code == 0
     ), f"Command failed with the following exception: {result.exception}"
     assert "Statue finished successfully" in result.output
     configuration.build_commands_map.assert_called_once_with(
-        sources=[Path(SOURCE1)], commands_filter=CommandsFilter()
+        sources=[source], commands_filter=CommandsFilter()
     )
     configuration.cache.save_evaluation.assert_called_once()
     assert_evaluation_was_printed(result, mock_evaluation_string)

--- a/tests/configuration/configuration/test_configuration_build_commands_map.py
+++ b/tests/configuration/configuration/test_configuration_build_commands_map.py
@@ -57,8 +57,8 @@ def test_get_commands_map_source_from_config(mock_build_commands):
         sources=[Path(SOURCE1)], commands_filter=CommandsFilter()
     )
     assert_commands_count(commands_map, 1)
-    assert_sources(commands_map, [SOURCE1])
-    assert_commands(commands_map, SOURCE1, [command])
+    assert_sources(commands_map, [Path(SOURCE1)])
+    assert_commands(commands_map, Path(SOURCE1), [command])
     assert_calls(
         mock_build_commands,
         [
@@ -85,8 +85,8 @@ def test_get_commands_map_source_not_from_config(mock_build_commands):
         sources=[Path(SOURCE2)], commands_filter=CommandsFilter()
     )
     assert_commands_count(commands_map, 1)
-    assert_sources(commands_map, [SOURCE2])
-    assert_commands(commands_map, SOURCE2, [command])
+    assert_sources(commands_map, [Path(SOURCE2)])
+    assert_commands(commands_map, Path(SOURCE2), [command])
     assert_calls(
         mock_build_commands,
         [call(CommandsFilter())],
@@ -118,9 +118,9 @@ def test_get_commands_map_with_commands_without_directives(mock_build_commands):
         sources=[Path(SOURCE1), Path(SOURCE2)], commands_filter=CommandsFilter()
     )
     assert_commands_count(commands_map, 3)
-    assert_sources(commands_map, [SOURCE1, SOURCE2])
-    assert_commands(commands_map, SOURCE1, [command1])
-    assert_commands(commands_map, SOURCE2, [command2, command3])
+    assert_sources(commands_map, [Path(SOURCE1), Path(SOURCE2)])
+    assert_commands(commands_map, Path(SOURCE1), [command1])
+    assert_commands(commands_map, Path(SOURCE2), [command2, command3])
     assert_calls(
         mock_build_commands,
         [call(CommandsFilter()), call(CommandsFilter())],
@@ -140,9 +140,9 @@ def test_get_commands_map_with_commands_and_directives(mock_build_commands):
         sources=[Path(SOURCE1), Path(SOURCE2)], commands_filter=commands_filter
     )
     assert_commands_count(commands_map, 3)
-    assert_sources(commands_map, [SOURCE1, SOURCE2])
-    assert_commands(commands_map, SOURCE1, [command1])
-    assert_commands(commands_map, SOURCE2, [command2, command3])
+    assert_sources(commands_map, [Path(SOURCE1), Path(SOURCE2)])
+    assert_commands(commands_map, Path(SOURCE1), [command1])
+    assert_commands(commands_map, Path(SOURCE2), [command2, command3])
     assert_calls(mock_build_commands, [call(commands_filter), call(commands_filter)])
 
 
@@ -163,9 +163,9 @@ def test_get_commands_map_with_source_context(mock_build_commands):
         commands_filter=CommandsFilter(denied_commands=[COMMAND3], contexts=[context2]),
     )
     assert_commands_count(commands_map, 3)
-    assert_sources(commands_map, [SOURCE1, SOURCE2])
-    assert_commands(commands_map, SOURCE1, [command1, command2])
-    assert_commands(commands_map, SOURCE2, [command3])
+    assert_sources(commands_map, [Path(SOURCE1), Path(SOURCE2)])
+    assert_commands(commands_map, Path(SOURCE1), [command1, command2])
+    assert_commands(commands_map, Path(SOURCE2), [command3])
     assert_calls(
         mock_build_commands,
         [
@@ -203,9 +203,9 @@ def test_get_commands_map_with_source_allow_list(mock_build_commands):
         ),
     )
     assert_commands_count(commands_map, 2)
-    assert_sources(commands_map, [SOURCE1, SOURCE2])
-    assert_commands(commands_map, SOURCE1, [command1])
-    assert_commands(commands_map, SOURCE2, [command2])
+    assert_sources(commands_map, [Path(SOURCE1), Path(SOURCE2)])
+    assert_commands(commands_map, Path(SOURCE1), [command1])
+    assert_commands(commands_map, Path(SOURCE2), [command2])
     assert_calls(
         mock_build_commands,
         [
@@ -239,9 +239,9 @@ def test_get_commands_map_with_source_deny_list(mock_build_commands):
         commands_filter=CommandsFilter(denied_commands=[COMMAND3], contexts=[context]),
     )
     assert_commands_count(commands_map, 4)
-    assert_sources(commands_map, [SOURCE1, SOURCE2])
-    assert_commands(commands_map, SOURCE1, [command1, command2])
-    assert_commands(commands_map, SOURCE2, [command3, command4])
+    assert_sources(commands_map, [Path(SOURCE1), Path(SOURCE2)])
+    assert_commands(commands_map, Path(SOURCE1), [command1, command2])
+    assert_commands(commands_map, Path(SOURCE2), [command3, command4])
     assert_calls(
         mock_build_commands,
         [
@@ -268,14 +268,13 @@ def test_get_commands_map_from_relative_path(mock_build_commands):
     )
     mock_build_commands.side_effect = [[command1, command2]]
     relative_source = Path(SOURCE2) / "i" / "am" / "relative"
-    relative_source_string = str(relative_source)
 
     commands_map = configuration.build_commands_map(
         sources=[relative_source], commands_filter=CommandsFilter()
     )
 
-    assert_sources(commands_map, [relative_source_string])
-    assert_commands(commands_map, relative_source_string, [command1, command2])
+    assert_sources(commands_map, [relative_source])
+    assert_commands(commands_map, relative_source, [command1, command2])
     assert_commands_count(commands_map, 2)
     assert_calls(
         mock_build_commands,

--- a/tests/evaluation/test_read_write_evaluation.py
+++ b/tests/evaluation/test_read_write_evaluation.py
@@ -32,7 +32,7 @@ def case_one_source_no_commands():
         total_execution_duration=0,
     )
     evaluation = Evaluation()
-    evaluation[SOURCE1] = SourceEvaluation()
+    evaluation[Path(SOURCE1)] = SourceEvaluation()
     return evaluation_json, evaluation
 
 
@@ -59,7 +59,7 @@ def case_one_source_one_commands():
         },
     )
     evaluation = Evaluation(total_execution_duration=total_execution_duration)
-    evaluation[SOURCE1] = SourceEvaluation(
+    evaluation[Path(SOURCE1)] = SourceEvaluation(
         commands_evaluations=[
             CommandEvaluation(
                 command=Command(COMMAND1),
@@ -103,7 +103,7 @@ def case_one_source_two_commands():
         },
     )
     evaluation = Evaluation(total_execution_duration=total_execution_duration)
-    evaluation[SOURCE1] = SourceEvaluation(
+    evaluation[Path(SOURCE1)] = SourceEvaluation(
         source_execution_duration=source_execution_duration,
         commands_evaluations=[
             CommandEvaluation(
@@ -165,7 +165,7 @@ def case_two_sources_two_commands():
         },
     )
     evaluation = Evaluation(total_execution_duration=total_execution_duration)
-    evaluation[SOURCE1] = SourceEvaluation(
+    evaluation[Path(SOURCE1)] = SourceEvaluation(
         source_execution_duration=source_execution_duration1,
         commands_evaluations=[
             CommandEvaluation(
@@ -176,7 +176,7 @@ def case_two_sources_two_commands():
             ),
         ],
     )
-    evaluation[SOURCE2] = SourceEvaluation(
+    evaluation[Path(SOURCE2)] = SourceEvaluation(
         source_execution_duration=source_execution_duration2,
         commands_evaluations=[
             CommandEvaluation(
@@ -227,5 +227,5 @@ def test_evaluation_save_as_json(evaluation_json, evaluation):
 def test_iterate_evaluation(evaluation_json, evaluation):
     for source in evaluation:
         assert evaluation[source] == SourceEvaluation.from_dict(
-            evaluation_json["sources_evaluations"][source]
+            evaluation_json["sources_evaluations"][source.as_posix()]
         )

--- a/tests/runners/test_asynchronous_runner.py
+++ b/tests/runners/test_asynchronous_runner.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import mock
 import pytest
 
@@ -51,7 +53,7 @@ async def test_asynchronous_runner_evaluate_source(mock_time, mock_tqdm_range):
     ) as evaluate_command_mock:
         await runner.evaluate_source(
             commands=[command1, command2],
-            source=SOURCE1,
+            source=Path(SOURCE1),
             evaluation=evaluation,
             main_bar=main_bar,
             source_bar_pos=pos,
@@ -61,14 +63,14 @@ async def test_asynchronous_runner_evaluate_source(mock_time, mock_tqdm_range):
         assert evaluate_command_mock.await_args_list == [
             mock.call(
                 command=command1,
-                source=SOURCE1,
+                source=Path(SOURCE1),
                 evaluation=evaluation,
                 source_bar=mock_tqdm_range.return_value.__enter__.return_value,
                 main_bar=main_bar,
             ),
             mock.call(
                 command=command2,
-                source=SOURCE1,
+                source=Path(SOURCE1),
                 evaluation=evaluation,
                 source_bar=mock_tqdm_range.return_value.__enter__.return_value,
                 main_bar=main_bar,
@@ -82,7 +84,7 @@ async def test_asynchronous_runner_evaluate_source(mock_time, mock_tqdm_range):
         leave=False,
         position=pos,
     )
-    evaluation.__getitem__.assert_called_once_with(SOURCE1)
+    evaluation.__getitem__.assert_called_once_with(Path(SOURCE1))
     execution_duration = evaluation.__getitem__.return_value.source_execution_duration
     assert execution_duration == pytest.approx(expected_execution_duration, rel=EPSILON)
 
@@ -91,7 +93,9 @@ async def test_asynchronous_runner_evaluate_source(mock_time, mock_tqdm_range):
 async def test_asynchronous_runner_evaluate_commands_map(mock_time, mock_tqdm_range):
     expected_execution_duration = set_execution_duration(mock_time)
     command1, command2, command3 = mock.Mock(), mock.Mock(), mock.Mock()
-    commands_map = CommandsMap({SOURCE1: [command1], SOURCE2: [command2, command3]})
+    commands_map = CommandsMap(
+        {Path(SOURCE1): [command1], Path(SOURCE2): [command2, command3]}
+    )
     runner = AsynchronousEvaluationRunner()
 
     with mock.patch.object(
@@ -102,7 +106,7 @@ async def test_asynchronous_runner_evaluate_commands_map(mock_time, mock_tqdm_ra
         assert evaluate_source_mock.await_args_list == [
             mock.call(
                 commands=[command1],
-                source=SOURCE1,
+                source=Path(SOURCE1),
                 evaluation=evaluation,
                 main_bar=mock_tqdm_range.return_value.__enter__.return_value,
                 max_source_name_length=7,
@@ -110,7 +114,7 @@ async def test_asynchronous_runner_evaluate_commands_map(mock_time, mock_tqdm_ra
             ),
             mock.call(
                 commands=[command2, command3],
-                source=SOURCE2,
+                source=Path(SOURCE2),
                 evaluation=evaluation,
                 main_bar=mock_tqdm_range.return_value.__enter__.return_value,
                 max_source_name_length=7,


### PR DESCRIPTION
**Description**
`click.option` should return `pathlib.Path` instead of `str`

**Tests**
fixed all relevant tests

**Alternatives**
Not relevant

**Additional context**
Python 3.9, Windows