### PR TITLE
Set history size in config

### DIFF
--- a/src/statue/cache.py
+++ b/src/statue/cache.py
@@ -3,7 +3,6 @@ import time
 from pathlib import Path
 from typing import List, Optional
 
-from statue.constants import DEFAULT_HISTORY_SIZE
 from statue.evaluation import Evaluation
 from statue.exceptions import CacheError
 
@@ -13,8 +12,8 @@ class Cache:
 
     def __init__(
         self,
+        size: int,
         cache_root_directory: Optional[Path] = None,
-        size: int = DEFAULT_HISTORY_SIZE,
     ):
         """
         Initialize cache.

--- a/src/statue/cache.py
+++ b/src/statue/cache.py
@@ -3,7 +3,7 @@ import time
 from pathlib import Path
 from typing import List, Optional
 
-from statue.constants import HISTORY_SIZE
+from statue.constants import DEFAULT_HISTORY_SIZE
 from statue.evaluation import Evaluation
 from statue.exceptions import CacheError
 
@@ -12,7 +12,9 @@ class Cache:
     """Cache files repository."""
 
     def __init__(
-        self, cache_root_directory: Optional[Path] = None, size: int = HISTORY_SIZE
+        self,
+        cache_root_directory: Optional[Path] = None,
+        size: int = DEFAULT_HISTORY_SIZE,
     ):
         """
         Initialize cache.

--- a/src/statue/cli/config/config_general.py
+++ b/src/statue/cli/config/config_general.py
@@ -8,12 +8,12 @@ from statue.runner import RunnerMode
 
 
 @config_cli.command("set-mode")
-@config_path_option
 @click.argument(
     "mode",
     type=click.Choice([mode.name.lower() for mode in RunnerMode], case_sensitive=False),
     callback=lambda ctx, param, value: (None if value is None else value.upper()),
 )
+@config_path_option
 def set_mode_cli(mode, config):
     """Choose which runner mode will be used by default."""
     if config is None:
@@ -21,4 +21,17 @@ def set_mode_cli(mode, config):
     configuration = ConfigurationBuilder.build_configuration_from_file(config)
     configuration.default_mode = RunnerMode[mode]
     configuration.to_toml(config)
-    click.echo("Mode successfully set!")
+    click.echo("Mode was successfully set!")
+
+
+@config_cli.command("set-history-size")
+@click.argument("size", type=int, nargs=1)
+@config_path_option
+def set_history_size_cli(size, config):
+    """Choose which runner mode will be used by default."""
+    if config is None:
+        config = ConfigurationBuilder.configuration_path()
+    configuration = ConfigurationBuilder.build_configuration_from_file(config)
+    configuration.cache.history_size = size
+    configuration.to_toml(config)
+    click.echo("History size was successfully set!")

--- a/src/statue/config/configuration.py
+++ b/src/statue/config/configuration.py
@@ -13,7 +13,7 @@ from statue.commands_map import CommandsMap
 from statue.config.commands_repository import CommandsRepository
 from statue.config.contexts_repository import ContextsRepository
 from statue.config.sources_repository import SourcesRepository
-from statue.constants import COMMANDS, CONTEXTS, GENERAL, MODE, SOURCES
+from statue.constants import COMMANDS, CONTEXTS, GENERAL, HISTORY_SIZE, MODE, SOURCES
 from statue.runner import RunnerMode
 
 
@@ -86,9 +86,15 @@ class Configuration:
         :return: Serialized representation dictionary
         :rtype: OrderedDict[str, Any]
         """
+        general_dict = OrderedDict(
+            [
+                (MODE, self.default_mode.name.lower()),
+                (HISTORY_SIZE, self.cache.history_size),
+            ]
+        )
         return OrderedDict(
             [
-                (GENERAL, {MODE: self.default_mode.name.lower()}),
+                (GENERAL, general_dict),
                 (CONTEXTS, self.contexts_repository.as_dict()),
                 (COMMANDS, self.commands_repository.as_dict()),
                 (SOURCES, self.sources_repository.as_dict()),

--- a/src/statue/config/configuration.py
+++ b/src/statue/config/configuration.py
@@ -1,7 +1,7 @@
 """Get Statue global configuration."""
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List
 from typing import OrderedDict as OrderedDictType
 
 import tomli_w
@@ -22,22 +22,22 @@ class Configuration:
 
     def __init__(
         self,
+        cache: Cache,
         default_mode: RunnerMode = RunnerMode.SYNC,
-        cache_root_directory: Optional[Path] = None,
     ):
         """
         Initialize configuration.
 
         :param default_mode: Default mode for evaluation runner
         :type default_mode: RunnerMode
-        :param cache_root_directory: Root directory for caching
-        :type cache_root_directory: Optional[Path]
+        :param cache: Cache instance for saving evaluations
+        :type cache: Cache
         """
-        self.default_mode = default_mode
-        self.cache = Cache(cache_root_directory)
+        self.cache = cache
         self.contexts_repository = ContextsRepository()
         self.sources_repository = SourcesRepository()
         self.commands_repository = CommandsRepository()
+        self.default_mode = default_mode
 
     def build_commands_map(
         self, sources: List[Path], commands_filter: CommandsFilter

--- a/src/statue/config/configuration_builder.py
+++ b/src/statue/config/configuration_builder.py
@@ -7,7 +7,15 @@ import tomli
 
 from statue.cache import Cache
 from statue.config.configuration import Configuration
-from statue.constants import COMMANDS, CONTEXTS, GENERAL, MODE, SOURCES
+from statue.constants import (
+    COMMANDS,
+    CONTEXTS,
+    DEFAULT_HISTORY_SIZE,
+    GENERAL,
+    HISTORY_SIZE,
+    MODE,
+    SOURCES,
+)
 from statue.exceptions import InvalidConfiguration, MissingConfiguration
 from statue.runner import RunnerMode
 
@@ -69,9 +77,10 @@ class ConfigurationBuilder:
         :raises InvalidConfiguration: Raised when some fields are invalid
             in configuration
         """
-        cache = Cache(cache_root_directory=cache_dir)
-        configuration = Configuration(cache=cache)
         general_configuration = statue_config_dict.get(GENERAL, {})
+        history_size = general_configuration.get(HISTORY_SIZE, DEFAULT_HISTORY_SIZE)
+        cache = Cache(cache_root_directory=cache_dir, size=history_size)
+        configuration = Configuration(cache=cache)
         if MODE in general_configuration:
             mode = general_configuration[MODE].upper()
             try:

--- a/src/statue/config/configuration_builder.py
+++ b/src/statue/config/configuration_builder.py
@@ -50,25 +50,26 @@ class ConfigurationBuilder:
         with statue_configuration_path.open(mode="rb") as configuration_file:
             statue_config = tomli.load(configuration_file)
         cache_dir = cls.cache_path(Path.cwd()) if cache_dir is None else cache_dir
-        configuration = Configuration(cache_root_directory=cache_dir)
-        cls.update_from_config(configuration=configuration, statue_config=statue_config)
-        return configuration
+        return cls.from_dict(cache_dir=cache_dir, statue_config_dict=statue_config)
 
     @classmethod
-    def update_from_config(
-        cls, configuration: Configuration, statue_config: MutableMapping[str, Any]
-    ):
+    def from_dict(
+        cls, cache_dir: Path, statue_config_dict: MutableMapping[str, Any]
+    ) -> Configuration:
         """
-        Update configuration from a loaded config map.
+        Build configuration from a loaded config map.
 
-        :param configuration: Configuration instance to be updated
-        :type configuration: Configuration
-        :param statue_config: Configuration map as loaded from config file
-        :type statue_config: MutableMapping[str, Any]
+        :param cache_dir: Directory for keeping cache.
+        :type cache_dir: Path
+        :param statue_config_dict: Configuration map as loaded from config file
+        :type statue_config_dict: MutableMapping[str, Any]
+        :return: Built configuration instance
+        :type: Configuration
         :raises InvalidConfiguration: Raised when some fields are invalid
             in configuration
         """
-        general_configuration = statue_config.get(GENERAL, {})
+        configuration = Configuration(cache_root_directory=cache_dir)
+        general_configuration = statue_config_dict.get(GENERAL, {})
         if MODE in general_configuration:
             mode = general_configuration[MODE].upper()
             try:
@@ -77,19 +78,20 @@ class ConfigurationBuilder:
                 raise InvalidConfiguration(
                     f"Got unexpected runner mode in configuration: {mode}"
                 ) from error
-        if CONTEXTS in statue_config:
+        if CONTEXTS in statue_config_dict:
             configuration.contexts_repository.update_from_config(
-                statue_config[CONTEXTS]
+                statue_config_dict[CONTEXTS]
             )
-        if SOURCES in statue_config:
+        if SOURCES in statue_config_dict:
             configuration.sources_repository.update_from_config(
-                config=statue_config[SOURCES],
+                config=statue_config_dict[SOURCES],
                 contexts_repository=configuration.contexts_repository,
             )
-        if COMMANDS in statue_config:
+        if COMMANDS in statue_config_dict:
             configuration.commands_repository.update_from_config(
-                statue_config[COMMANDS]
+                statue_config_dict[COMMANDS]
             )
+        return configuration
 
     @classmethod
     def configuration_path(cls, directory: Optional[Path] = None) -> Path:

--- a/src/statue/config/configuration_builder.py
+++ b/src/statue/config/configuration_builder.py
@@ -5,6 +5,7 @@ from typing import Any, MutableMapping, Optional, Union
 
 import tomli
 
+from statue.cache import Cache
 from statue.config.configuration import Configuration
 from statue.constants import COMMANDS, CONTEXTS, GENERAL, MODE, SOURCES
 from statue.exceptions import InvalidConfiguration, MissingConfiguration
@@ -68,7 +69,8 @@ class ConfigurationBuilder:
         :raises InvalidConfiguration: Raised when some fields are invalid
             in configuration
         """
-        configuration = Configuration(cache_root_directory=cache_dir)
+        cache = Cache(cache_root_directory=cache_dir)
+        configuration = Configuration(cache=cache)
         general_configuration = statue_config_dict.get(GENERAL, {})
         if MODE in general_configuration:
             mode = general_configuration[MODE].upper()

--- a/src/statue/constants.py
+++ b/src/statue/constants.py
@@ -3,7 +3,7 @@
 STATUE = "STATUE"
 ENCODING = "utf-8"
 
-HISTORY_SIZE = 30
+DEFAULT_HISTORY_SIZE = 30
 
 GENERAL = "general"
 COMMANDS = "commands"

--- a/src/statue/constants.py
+++ b/src/statue/constants.py
@@ -23,6 +23,7 @@ PARENT = "parent"
 ALLOWED_BY_DEFAULT = "allowed_by_default"
 VERSION = "version"
 MODE = "mode"
+HISTORY_SIZE = "history_size"
 
 DATETIME_FORMAT = "%m/%d/%Y, %H:%M:%S"
 BAR_FORMAT = "{l_bar}{bar}| {n_fmt}/{total_fmt}"

--- a/statue.toml
+++ b/statue.toml
@@ -1,5 +1,6 @@
 [general]
 mode = "async"
+history_size = 30
 
 [contexts.documentation]
 help = "Commands regarding code documentation."

--- a/statue.toml
+++ b/statue.toml
@@ -140,7 +140,7 @@ args = [
 allowed_contexts = [
     "documentation",
 ]
-version = "2.13.1"
+version = "2.13.2"
 
 [commands.pylint.test]
 add_args = [

--- a/tests/cache/test_cache_constructor.py
+++ b/tests/cache/test_cache_constructor.py
@@ -1,54 +1,59 @@
+import random
+
 from statue.cache import Cache
-from statue.constants import DEFAULT_HISTORY_SIZE
 
 
 def test_cache_constructor_with_none_root_directory(tmp_path):
-    cache = Cache()
+    size = random.randint(1, 100)
+    cache = Cache(size=size)
     assert cache.cache_root_directory is None
     assert cache.evaluations_dir is None
     assert not cache.all_evaluation_paths
-    assert cache.history_size == DEFAULT_HISTORY_SIZE
+    assert cache.history_size == size
 
 
 def test_cache_constructor_with_non_existing_directory(tmp_path):
     cache_dir = tmp_path / "cache"
     assert not cache_dir.exists()
 
-    cache = Cache(cache_dir)
+    size = random.randint(1, 100)
+    cache = Cache(size=size, cache_root_directory=cache_dir)
     assert cache.cache_root_directory == cache_dir
     assert cache_dir.exists()
     assert cache.evaluations_dir == cache_dir / "evaluations"
     assert cache.evaluations_dir.exists()
     assert not cache.all_evaluation_paths
-    assert cache.history_size == DEFAULT_HISTORY_SIZE
+    assert cache.history_size == size
 
 
 def test_cache_constructor_with_existing_directory(tmp_path):
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
 
-    cache = Cache(cache_dir)
+    size = random.randint(1, 100)
+    cache = Cache(size=size, cache_root_directory=cache_dir)
 
     assert cache.cache_root_directory == cache_dir
     assert cache_dir.exists()
     assert cache.evaluations_dir == cache_dir / "evaluations"
     assert cache.evaluations_dir.exists()
     assert not cache.all_evaluation_paths
-    assert cache.history_size == DEFAULT_HISTORY_SIZE
+    assert cache.history_size == size
 
 
 def test_cache_constructor_with_evaluations_directory_already_existing(tmp_path):
     cache_dir = tmp_path / "cache"
     (cache_dir / "evaluations").mkdir(parents=True)
 
-    cache = Cache(cache_dir)
+    size = random.randint(1, 100)
+    cache = Cache(size=size, cache_root_directory=cache_dir)
 
     assert cache.cache_root_directory == cache_dir
     assert cache_dir.exists()
     assert cache.evaluations_dir == cache_dir / "evaluations"
     assert cache.evaluations_dir.exists()
     assert not cache.all_evaluation_paths
-    assert cache.history_size == DEFAULT_HISTORY_SIZE
+    assert cache.history_size == size
 
 
 def test_cache_constructor_with_existing_evaluations(tmp_path):
@@ -67,7 +72,8 @@ def test_cache_constructor_with_existing_evaluations(tmp_path):
     for evaluation_file in evaluation_paths:
         evaluation_file.touch()
 
-    cache = Cache(cache_dir)
+    size = random.randint(1, 100)
+    cache = Cache(size=size, cache_root_directory=cache_dir)
 
     assert cache.cache_root_directory == cache_dir
     assert cache_dir.exists()
@@ -77,7 +83,7 @@ def test_cache_constructor_with_existing_evaluations(tmp_path):
     assert cache.recent_evaluation_path == evaluation_paths[0]
     for i, evaluation_path in enumerate(evaluation_paths):
         assert cache.evaluation_path(i) == evaluation_path
-    assert cache.history_size == DEFAULT_HISTORY_SIZE
+    assert cache.history_size == size
 
 
 def test_cache_constructor_with_history_size(tmp_path):

--- a/tests/cache/test_cache_constructor.py
+++ b/tests/cache/test_cache_constructor.py
@@ -1,0 +1,89 @@
+from statue.cache import Cache
+from statue.constants import DEFAULT_HISTORY_SIZE
+
+
+def test_cache_constructor_with_none_root_directory(tmp_path):
+    cache = Cache()
+    assert cache.cache_root_directory is None
+    assert cache.evaluations_dir is None
+    assert not cache.all_evaluation_paths
+    assert cache.history_size == DEFAULT_HISTORY_SIZE
+
+
+def test_cache_constructor_with_non_existing_directory(tmp_path):
+    cache_dir = tmp_path / "cache"
+    assert not cache_dir.exists()
+
+    cache = Cache(cache_dir)
+    assert cache.cache_root_directory == cache_dir
+    assert cache_dir.exists()
+    assert cache.evaluations_dir == cache_dir / "evaluations"
+    assert cache.evaluations_dir.exists()
+    assert not cache.all_evaluation_paths
+    assert cache.history_size == DEFAULT_HISTORY_SIZE
+
+
+def test_cache_constructor_with_existing_directory(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    cache = Cache(cache_dir)
+
+    assert cache.cache_root_directory == cache_dir
+    assert cache_dir.exists()
+    assert cache.evaluations_dir == cache_dir / "evaluations"
+    assert cache.evaluations_dir.exists()
+    assert not cache.all_evaluation_paths
+    assert cache.history_size == DEFAULT_HISTORY_SIZE
+
+
+def test_cache_constructor_with_evaluations_directory_already_existing(tmp_path):
+    cache_dir = tmp_path / "cache"
+    (cache_dir / "evaluations").mkdir(parents=True)
+
+    cache = Cache(cache_dir)
+
+    assert cache.cache_root_directory == cache_dir
+    assert cache_dir.exists()
+    assert cache.evaluations_dir == cache_dir / "evaluations"
+    assert cache.evaluations_dir.exists()
+    assert not cache.all_evaluation_paths
+    assert cache.history_size == DEFAULT_HISTORY_SIZE
+
+
+def test_cache_constructor_with_existing_evaluations(tmp_path):
+    cache_dir = tmp_path / "cache"
+    evaluations_dir = cache_dir / "evaluations"
+    evaluations_dir.mkdir(parents=True)
+    evaluation_paths = [
+        evaluations_dir / "evaluation-1000.json",
+        evaluations_dir / "evaluation-999.json",
+        evaluations_dir / "evaluation-900.json",
+        evaluations_dir / "evaluation-889.json",
+        evaluations_dir / "evaluation-700.json",
+        evaluations_dir / "evaluation-88.json",
+        evaluations_dir / "evaluation-70.json",
+    ]
+    for evaluation_file in evaluation_paths:
+        evaluation_file.touch()
+
+    cache = Cache(cache_dir)
+
+    assert cache.cache_root_directory == cache_dir
+    assert cache_dir.exists()
+    assert cache.evaluations_dir == cache_dir / "evaluations"
+    assert cache.evaluations_dir.exists()
+    assert cache.all_evaluation_paths == evaluation_paths
+    assert cache.recent_evaluation_path == evaluation_paths[0]
+    for i, evaluation_path in enumerate(evaluation_paths):
+        assert cache.evaluation_path(i) == evaluation_path
+    assert cache.history_size == DEFAULT_HISTORY_SIZE
+
+
+def test_cache_constructor_with_history_size(tmp_path):
+    history_size = 8
+    cache = Cache(size=history_size)
+    assert cache.cache_root_directory is None
+    assert cache.evaluations_dir is None
+    assert not cache.all_evaluation_paths
+    assert cache.history_size == history_size

--- a/tests/cache/test_cache_save_evaluation.py
+++ b/tests/cache/test_cache_save_evaluation.py
@@ -9,79 +9,6 @@ from statue.constants import DEFAULT_HISTORY_SIZE
 from statue.exceptions import CacheError
 
 
-def test_cache_constructor_with_none_root_directory(tmp_path):
-    cache = Cache()
-    assert cache.cache_root_directory is None
-    assert cache.evaluations_dir is None
-    assert not cache.all_evaluation_paths
-
-
-def test_cache_constructor_with_non_existing_directory(tmp_path):
-    cache_dir = tmp_path / "cache"
-    assert not cache_dir.exists()
-
-    cache = Cache(cache_dir)
-    assert cache.cache_root_directory == cache_dir
-    assert cache_dir.exists()
-    assert cache.evaluations_dir == cache_dir / "evaluations"
-    assert cache.evaluations_dir.exists()
-    assert not cache.all_evaluation_paths
-
-
-def test_cache_constructor_with_existing_directory(tmp_path):
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-
-    cache = Cache(cache_dir)
-
-    assert cache.cache_root_directory == cache_dir
-    assert cache_dir.exists()
-    assert cache.evaluations_dir == cache_dir / "evaluations"
-    assert cache.evaluations_dir.exists()
-    assert not cache.all_evaluation_paths
-
-
-def test_cache_constructor_with_evaluations_directory_already_existing(tmp_path):
-    cache_dir = tmp_path / "cache"
-    (cache_dir / "evaluations").mkdir(parents=True)
-
-    cache = Cache(cache_dir)
-
-    assert cache.cache_root_directory == cache_dir
-    assert cache_dir.exists()
-    assert cache.evaluations_dir == cache_dir / "evaluations"
-    assert cache.evaluations_dir.exists()
-    assert not cache.all_evaluation_paths
-
-
-def test_cache_constructor_with_existing_evaluations(tmp_path):
-    cache_dir = tmp_path / "cache"
-    evaluations_dir = cache_dir / "evaluations"
-    evaluations_dir.mkdir(parents=True)
-    evaluation_paths = [
-        evaluations_dir / "evaluation-1000.json",
-        evaluations_dir / "evaluation-999.json",
-        evaluations_dir / "evaluation-900.json",
-        evaluations_dir / "evaluation-889.json",
-        evaluations_dir / "evaluation-700.json",
-        evaluations_dir / "evaluation-88.json",
-        evaluations_dir / "evaluation-70.json",
-    ]
-    for evaluation_file in evaluation_paths:
-        evaluation_file.touch()
-
-    cache = Cache(cache_dir)
-
-    assert cache.cache_root_directory == cache_dir
-    assert cache_dir.exists()
-    assert cache.evaluations_dir == cache_dir / "evaluations"
-    assert cache.evaluations_dir.exists()
-    assert cache.all_evaluation_paths == evaluation_paths
-    assert cache.recent_evaluation_path == evaluation_paths[0]
-    for i, evaluation_path in enumerate(evaluation_paths):
-        assert cache.evaluation_path(i) == evaluation_path
-
-
 def test_save_evaluation(tmp_path, mock_time):
     time = 12300566
     cache_dir = tmp_path / "cache"
@@ -142,7 +69,7 @@ def test_cache_save_evaluation_fails_when_no_root_dir_was_set():
 
 
 @parametrize(argnames="invalid_evaluation_index", argvalues=[-1, 10])
-def test_cache_get_evaluation_with_invalid_context_(tmp_path, invalid_evaluation_index):
+def test_cache_get_evaluation_with_invalid_index(tmp_path, invalid_evaluation_index):
     cache_dir = tmp_path / "cache"
     evaluations_dir = cache_dir / "evaluations"
     evaluations_dir.mkdir(parents=True)

--- a/tests/cli/config/test_config_init.py
+++ b/tests/cli/config/test_config_init.py
@@ -33,7 +33,7 @@ def mock_update_sources_repository(mocker):
 
 
 def dummy_configuration():
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(
         Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
         Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),

--- a/tests/cli/config/test_config_set_history_size.py
+++ b/tests/cli/config/test_config_set_history_size.py
@@ -1,0 +1,39 @@
+import random
+
+from statue.cli import statue_cli
+
+
+def test_config_set_history_size_without_specifying_path(
+    mock_configuration_path, mock_build_configuration_from_file, cli_runner
+):
+    size = random.randint(1, 100)
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.history_size = None
+
+    result = cli_runner.invoke(statue_cli, ["config", "set-history-size", str(size)])
+
+    assert result.exit_code == 0
+    assert configuration.cache.history_size == size
+    configuration.to_toml.assert_called_once_with(mock_configuration_path.return_value)
+
+
+def test_config_set_history_size_with_specified_path(
+    mock_configuration_path,
+    mock_build_configuration_from_file,
+    cli_runner,
+    tmp_path,
+):
+    size = random.randint(1, 100)
+    config_path = tmp_path / "statue.toml"
+    config_path.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.history_size = None
+    result = cli_runner.invoke(
+        statue_cli,
+        ["config", "set-history-size", str(size), "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 0
+    assert configuration.cache.history_size == size
+    configuration.to_toml.assert_called_once_with(config_path)
+    mock_configuration_path.assert_not_called()

--- a/tests/cli/config/test_interactive_sources_adder.py
+++ b/tests/cli/config/test_interactive_sources_adder.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from statue.cli.interactive_sources_adder import InteractiveSourcesAdder
@@ -37,7 +38,7 @@ expend_parametrization = pytest.mark.parametrize(
 
 
 def dummy_configuration():
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(
         Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
         Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
@@ -71,7 +72,7 @@ def test_interactive_sources_adder_one_source_simple_addition(
 def test_interactive_sources_adder_no_addition(no_word, cli_runner, tmp_path):
     source_path = tmp_path / SOURCE1
     source_path.touch()
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     with cli_runner.isolation(input=f"{no_word}\n"):
         InteractiveSourcesAdder.update_sources_repository(
             configuration=configuration, sources=[source_path]

--- a/tests/cli/test_command_cli.py
+++ b/tests/cli/test_command_cli.py
@@ -1,3 +1,5 @@
+import mock
+
 from statue.cli import statue_cli
 from statue.command_builder import CommandBuilder, ContextSpecification
 from statue.config.configuration import Configuration
@@ -166,7 +168,7 @@ def test_command_install_with_default_verbosity(
         command_builder_mock(name=COMMAND2, installed=False),
         command_builder_mock(name=COMMAND3, installed=False),
     ]
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.commands_repository.add_command_builders(*command_builders)
     mock_build_configuration_from_file.return_value = configuration
     result = cli_runner.invoke(statue_cli, ["command", "install"])
@@ -181,7 +183,7 @@ def test_command_install_with_verbose(cli_runner, mock_build_configuration_from_
         command_builder_mock(name=COMMAND2, installed=False),
         command_builder_mock(name=COMMAND3, installed=False),
     ]
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.commands_repository.add_command_builders(*command_builders)
     mock_build_configuration_from_file.return_value = configuration
     result = cli_runner.invoke(statue_cli, ["command", "install", "--verbose"])
@@ -200,7 +202,7 @@ def test_command_install_only_uninstalled(
             name=COMMAND3, installed=True, version="0.2.8", installed_version="0.2.7"
         ),
     )
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.commands_repository.add_command_builders(
         command_builder1, command_builder2, command_builder3
     )

--- a/tests/configuration/configuration/test_configuration_as_dict.py
+++ b/tests/configuration/configuration/test_configuration_as_dict.py
@@ -1,10 +1,11 @@
+import random
 from collections import OrderedDict
 
 import mock
 import pytest
 
 from statue.config.configuration import Configuration
-from statue.constants import COMMANDS, CONTEXTS, GENERAL, MODE, SOURCES
+from statue.constants import COMMANDS, CONTEXTS, GENERAL, HISTORY_SIZE, MODE, SOURCES
 from statue.runner import RunnerMode
 
 
@@ -13,12 +14,15 @@ def test_configuration_as_dict_default(
     mock_commands_repository_as_dict,
     mock_sources_repository_as_dict,
 ):
-    configuration = Configuration(cache=mock.Mock())
+    size = random.randint(1, 100)
+    cache = mock.Mock()
+    cache.history_size = size
+    configuration = Configuration(cache=cache)
     configuration_dict = configuration.as_dict()
 
     assert isinstance(configuration_dict, OrderedDict)
     assert list(configuration_dict.keys()) == [GENERAL, CONTEXTS, COMMANDS, SOURCES]
-    assert configuration_dict[GENERAL] == {MODE: "sync"}
+    assert configuration_dict[GENERAL] == {MODE: "sync", HISTORY_SIZE: size}
     assert configuration_dict[CONTEXTS] == mock_contexts_repository_as_dict.return_value
     assert configuration_dict[COMMANDS] == mock_commands_repository_as_dict.return_value
     assert configuration_dict[SOURCES] == mock_sources_repository_as_dict.return_value
@@ -31,12 +35,15 @@ def test_configuration_as_dict_with_runner_mode(
     mock_commands_repository_as_dict,
     mock_sources_repository_as_dict,
 ):
-    configuration = Configuration(cache=mock.Mock(), default_mode=mode)
+    size = random.randint(1, 100)
+    cache = mock.Mock()
+    cache.history_size = size
+    configuration = Configuration(cache=cache, default_mode=mode)
     configuration_dict = configuration.as_dict()
 
     assert isinstance(configuration_dict, OrderedDict)
     assert list(configuration_dict.keys()) == [GENERAL, CONTEXTS, COMMANDS, SOURCES]
-    assert configuration_dict[GENERAL] == {MODE: mode.name.lower()}
+    assert configuration_dict[GENERAL] == {MODE: mode.name.lower(), HISTORY_SIZE: size}
     assert configuration_dict[CONTEXTS] == mock_contexts_repository_as_dict.return_value
     assert configuration_dict[COMMANDS] == mock_commands_repository_as_dict.return_value
     assert configuration_dict[SOURCES] == mock_sources_repository_as_dict.return_value

--- a/tests/configuration/configuration/test_configuration_as_dict.py
+++ b/tests/configuration/configuration/test_configuration_as_dict.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+import mock
 import pytest
 
 from statue.config.configuration import Configuration
@@ -12,7 +13,7 @@ def test_configuration_as_dict_default(
     mock_commands_repository_as_dict,
     mock_sources_repository_as_dict,
 ):
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration_dict = configuration.as_dict()
 
     assert isinstance(configuration_dict, OrderedDict)
@@ -30,7 +31,7 @@ def test_configuration_as_dict_with_runner_mode(
     mock_commands_repository_as_dict,
     mock_sources_repository_as_dict,
 ):
-    configuration = Configuration(default_mode=mode)
+    configuration = Configuration(cache=mock.Mock(), default_mode=mode)
     configuration_dict = configuration.as_dict()
 
     assert isinstance(configuration_dict, OrderedDict)

--- a/tests/configuration/configuration/test_configuration_basics.py
+++ b/tests/configuration/configuration/test_configuration_basics.py
@@ -1,25 +1,14 @@
+import mock
+
 from statue.config.configuration import Configuration
-from statue.constants import DEFAULT_HISTORY_SIZE
 from statue.runner import RunnerMode
 
 
-def test_configuration_default_constructor():
-    configuration = Configuration()
+def test_configuration_constructor_without_mode(tmp_path):
+    cache = mock.Mock()
+    configuration = Configuration(cache=cache)
 
-    assert configuration.cache.cache_root_directory is None
-    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
-    assert len(configuration.commands_repository) == 0
-    assert len(configuration.contexts_repository) == 0
-    assert len(configuration.sources_repository) == 0
-    assert configuration.default_mode == RunnerMode.SYNC
-
-
-def test_configuration_constructor_with_cache_dir(tmp_path):
-    cache_dir = tmp_path / "cache"
-    configuration = Configuration(cache_root_directory=cache_dir)
-
-    assert configuration.cache.cache_root_directory == cache_dir
-    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
+    assert configuration.cache == cache
     assert len(configuration.commands_repository) == 0
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0
@@ -27,10 +16,10 @@ def test_configuration_constructor_with_cache_dir(tmp_path):
 
 
 def test_configuration_with_sync_default_mode():
-    configuration = Configuration(default_mode=RunnerMode.SYNC)
+    cache = mock.Mock()
+    configuration = Configuration(cache=cache, default_mode=RunnerMode.SYNC)
 
-    assert configuration.cache.cache_root_directory is None
-    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
+    assert configuration.cache == cache
     assert len(configuration.commands_repository) == 0
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0
@@ -38,10 +27,10 @@ def test_configuration_with_sync_default_mode():
 
 
 def test_configuration_with_async_default_mode():
-    configuration = Configuration(default_mode=RunnerMode.ASYNC)
+    cache = mock.Mock()
+    configuration = Configuration(cache=cache, default_mode=RunnerMode.ASYNC)
 
-    assert configuration.cache.cache_root_directory is None
-    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
+    assert configuration.cache == cache
     assert len(configuration.commands_repository) == 0
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0

--- a/tests/configuration/configuration/test_configuration_basics.py
+++ b/tests/configuration/configuration/test_configuration_basics.py
@@ -1,5 +1,5 @@
 from statue.config.configuration import Configuration
-from statue.constants import HISTORY_SIZE
+from statue.constants import DEFAULT_HISTORY_SIZE
 from statue.runner import RunnerMode
 
 
@@ -7,7 +7,7 @@ def test_configuration_default_constructor():
     configuration = Configuration()
 
     assert configuration.cache.cache_root_directory is None
-    assert configuration.cache.history_size == HISTORY_SIZE
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert len(configuration.commands_repository) == 0
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0
@@ -19,7 +19,7 @@ def test_configuration_constructor_with_cache_dir(tmp_path):
     configuration = Configuration(cache_root_directory=cache_dir)
 
     assert configuration.cache.cache_root_directory == cache_dir
-    assert configuration.cache.history_size == HISTORY_SIZE
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert len(configuration.commands_repository) == 0
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0
@@ -30,7 +30,7 @@ def test_configuration_with_sync_default_mode():
     configuration = Configuration(default_mode=RunnerMode.SYNC)
 
     assert configuration.cache.cache_root_directory is None
-    assert configuration.cache.history_size == HISTORY_SIZE
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert len(configuration.commands_repository) == 0
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0
@@ -41,7 +41,7 @@ def test_configuration_with_async_default_mode():
     configuration = Configuration(default_mode=RunnerMode.ASYNC)
 
     assert configuration.cache.cache_root_directory is None
-    assert configuration.cache.history_size == HISTORY_SIZE
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert len(configuration.commands_repository) == 0
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.sources_repository) == 0

--- a/tests/configuration/configuration/test_configuration_build_commands.py
+++ b/tests/configuration/configuration/test_configuration_build_commands.py
@@ -7,7 +7,7 @@ from tests.util import command_builder_mock
 
 def test_build_commands_from_empty_list():
     commands_filter = mock.Mock()
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     commands = configuration.build_commands(commands_filter=commands_filter)
 
     assert commands == []
@@ -15,7 +15,7 @@ def test_build_commands_from_empty_list():
 
 def test_build_commands_with_one_command_builder_passing_filter():
     command_builder = command_builder_mock(name=COMMAND1)
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.commands_repository.add_command_builders(command_builder)
     commands_filter = mock.Mock()
     commands_filter.contexts = [CONTEXT1, CONTEXT2]
@@ -28,7 +28,7 @@ def test_build_commands_with_one_command_builder_passing_filter():
 
 def test_build_commands_with_one_command_builder_not_passing_filter():
     command_builder = command_builder_mock(name=COMMAND1)
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.commands_repository.add_command_builders(command_builder)
     commands_filter = mock.Mock()
     commands_filter.contexts = [CONTEXT1, CONTEXT2]
@@ -45,7 +45,7 @@ def test_build_commands_with_few_passing_command_builders():
         command_builder_mock(name=COMMAND2),
         command_builder_mock(name=COMMAND3),
     )
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.commands_repository.add_command_builders(
         command_builder1, command_builder2, command_builder3
     )

--- a/tests/configuration/configuration/test_configuration_build_commands_map.py
+++ b/tests/configuration/configuration/test_configuration_build_commands_map.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest.mock import Mock, call
 
+import mock
 import pytest
 
 from statue.commands_filter import CommandsFilter
@@ -47,7 +48,7 @@ def mock_build_commands(mocker):
 def test_get_commands_map_source_from_config(mock_build_commands):
     command = Mock()
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(context)
     configuration.sources_repository[Path(SOURCE1)] = CommandsFilter(
         allowed_commands=[COMMAND1], contexts=[context]
@@ -75,7 +76,7 @@ def test_get_commands_map_source_from_config(mock_build_commands):
 def test_get_commands_map_source_not_from_config(mock_build_commands):
     command = Mock()
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(context)
     configuration.sources_repository[Path(SOURCE1)] = CommandsFilter(
         denied_commands=[COMMAND3], contexts=[context]
@@ -95,7 +96,7 @@ def test_get_commands_map_source_not_from_config(mock_build_commands):
 
 def test_get_commands_map_with_no_commands(mock_build_commands):
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(context)
     configuration.sources_repository[Path(SOURCE1)] = CommandsFilter()
     configuration.sources_repository[Path(SOURCE2)] = CommandsFilter()
@@ -110,7 +111,7 @@ def test_get_commands_map_with_no_commands(mock_build_commands):
 
 def test_get_commands_map_with_commands_without_directives(mock_build_commands):
     command1, command2, command3 = Mock(), Mock(), Mock()
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.sources_repository[Path(SOURCE1)] = CommandsFilter()
     configuration.sources_repository[Path(SOURCE2)] = CommandsFilter()
     mock_build_commands.side_effect = [[command1], [command2, command3]]
@@ -130,7 +131,7 @@ def test_get_commands_map_with_commands_without_directives(mock_build_commands):
 def test_get_commands_map_with_commands_and_directives(mock_build_commands):
     command1, command2, command3 = Mock(), Mock(), Mock()
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(context)
     configuration.sources_repository[Path(SOURCE1)] = CommandsFilter()
     configuration.sources_repository[Path(SOURCE2)] = CommandsFilter()
@@ -151,7 +152,7 @@ def test_get_commands_map_with_source_context(mock_build_commands):
     context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
         name=CONTEXT2, help=CONTEXT_HELP_STRING2
     )
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(context1, context2)
     configuration.sources_repository[Path(SOURCE1)] = CommandsFilter(
         contexts=[context1]
@@ -188,7 +189,7 @@ def test_get_commands_map_with_source_context(mock_build_commands):
 def test_get_commands_map_with_source_allow_list(mock_build_commands):
     command1, command2 = Mock(), Mock()
     mock_build_commands.side_effect = [[command1], [command2]]
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(
         Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
     )
@@ -228,7 +229,7 @@ def test_get_commands_map_with_source_deny_list(mock_build_commands):
     )
     mock_build_commands.side_effect = [[command1, command2], [command3, command4]]
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(context)
     configuration.sources_repository[Path(SOURCE1)] = CommandsFilter()
     configuration.sources_repository[Path(SOURCE2)] = CommandsFilter(
@@ -258,7 +259,7 @@ def test_get_commands_map_from_relative_path(mock_build_commands):
     context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
         name=CONTEXT2, help=CONTEXT_HELP_STRING2
     )
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.contexts_repository.add_contexts(context1, context2)
     configuration.sources_repository[Path(SOURCE1)] = CommandsFilter(
         contexts=[context1]

--- a/tests/configuration/configuration/test_configuration_to_toml.py
+++ b/tests/configuration/configuration/test_configuration_to_toml.py
@@ -4,7 +4,7 @@ from statue.config.configuration import Configuration
 
 
 def test_configuration_to_toml():
-    configuration = Configuration()
+    configuration = Configuration(cache=mock.Mock())
     configuration.as_dict = mock.Mock()
     path = mock.MagicMock()
     path_fd = path.open.return_value.__enter__.return_value

--- a/tests/configuration/configuration_builder/test_configuration_builder_build_from_file.py
+++ b/tests/configuration/configuration_builder/test_configuration_builder_build_from_file.py
@@ -4,9 +4,14 @@ from statue.config.configuration_builder import ConfigurationBuilder
 from statue.exceptions import MissingConfiguration
 
 
+@pytest.fixture
+def mock_configuration_from_dict(mocker):
+    return mocker.patch.object(ConfigurationBuilder, "from_dict")
+
+
 def test_configuration_builder_build_with_existing_path(
     tmp_path,
-    mock_update_from_config,
+    mock_configuration_from_dict,
     mock_cache_path,
     mock_toml_load,
     mock_cwd,
@@ -22,15 +27,17 @@ def test_configuration_builder_build_with_existing_path(
         statue_configuration_path=statue_config_path
     )
 
+    assert configuration == mock_configuration_from_dict.return_value
     mock_toml_load.assert_called_once()
-    mock_update_from_config(configuration=configuration, statue_config=statue_config)
+    mock_configuration_from_dict.assert_called_once_with(
+        statue_config_dict=statue_config, cache_dir=cache_path
+    )
     mock_cache_path.assert_called_once_with(mock_cwd)
-    assert configuration.cache.cache_root_directory == cache_path
 
 
 def test_configuration_builder_build_with_no_config_path(
     tmp_path,
-    mock_update_from_config,
+    mock_configuration_from_dict,
     mock_configuration_path,
     mock_cache_path,
     mock_toml_load,
@@ -44,18 +51,18 @@ def test_configuration_builder_build_with_no_config_path(
 
     configuration = ConfigurationBuilder.build_configuration_from_file()
 
+    assert configuration == mock_configuration_from_dict.return_value
     mock_toml_load.assert_called_once()
-    mock_update_from_config.assert_called_once_with(
-        configuration=configuration, statue_config=statue_config
+    mock_configuration_from_dict.assert_called_once_with(
+        cache_dir=cache_path, statue_config_dict=statue_config
     )
     mock_configuration_path.assert_called_once_with()
     mock_cache_path.assert_called_once_with(mock_cwd)
-    assert configuration.cache.cache_root_directory == cache_path
 
 
 def test_configuration_builder_build_with_specified_cache(
     tmp_path,
-    mock_update_from_config,
+    mock_configuration_from_dict,
     mock_cache_path,
     mock_toml_load,
 ):
@@ -70,17 +77,17 @@ def test_configuration_builder_build_with_specified_cache(
         cache_dir=cache_path,
     )
 
+    assert configuration == mock_configuration_from_dict.return_value
     mock_toml_load.assert_called_once()
-    mock_update_from_config.assert_called_once_with(
-        configuration=configuration, statue_config=statue_config
+    mock_configuration_from_dict.assert_called_once_with(
+        cache_dir=cache_path, statue_config_dict=statue_config
     )
     mock_cache_path.assert_not_called()
-    assert configuration.cache.cache_root_directory == cache_path
 
 
 def test_configuration_builder_build_with_non_existing_path(
     tmp_path,
-    mock_update_from_config,
+    mock_configuration_from_dict,
     mock_cache_path,
     mock_toml_load,
 ):
@@ -95,5 +102,5 @@ def test_configuration_builder_build_with_non_existing_path(
         )
 
     mock_toml_load.assert_not_called()
-    mock_update_from_config.assert_not_called()
+    mock_configuration_from_dict.assert_not_called()
     mock_cache_path.assert_not_called()

--- a/tests/configuration/configuration_builder/test_configuration_builder_update_from_config.py
+++ b/tests/configuration/configuration_builder/test_configuration_builder_update_from_config.py
@@ -3,99 +3,117 @@ from unittest import mock
 import pytest
 from pytest_cases import parametrize
 
+from statue.config.commands_repository import CommandsRepository
 from statue.config.configuration import Configuration
 from statue.config.configuration_builder import ConfigurationBuilder
-from statue.constants import COMMANDS, CONTEXTS, GENERAL, MODE, SOURCES
+from statue.config.contexts_repository import ContextsRepository
+from statue.config.sources_repository import SourcesRepository
+from statue.constants import (
+    COMMANDS,
+    CONTEXTS,
+    DEFAULT_HISTORY_SIZE,
+    GENERAL,
+    MODE,
+    SOURCES,
+)
 from statue.exceptions import InvalidConfiguration
 from statue.runner import RunnerMode
 
 
-def test_configuration_builder_update_from_empty_config():
-    configuration = Configuration()
-
-    ConfigurationBuilder.update_from_config(
-        configuration=configuration, statue_config={}
+def test_configuration_builder_from_empty_config(tmp_path):
+    cache_dir = tmp_path / ".statue"
+    configuration = ConfigurationBuilder.from_dict(
+        cache_dir=cache_dir, statue_config_dict={}
     )
 
+    assert isinstance(configuration, Configuration)
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.commands_repository) == 0
     assert len(configuration.sources_repository) == 0
+    assert configuration.cache.cache_root_directory == cache_dir
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert configuration.default_mode == RunnerMode.SYNC
 
 
 @parametrize(argnames="mode", argvalues=[RunnerMode.SYNC, RunnerMode.ASYNC])
-def test_configuration_builder_update_mode_upper_case(mode):
-    configuration = Configuration()
-
-    ConfigurationBuilder.update_from_config(
-        configuration=configuration, statue_config={GENERAL: {MODE: mode.name.upper()}}
+def test_configuration_builder_from_dict_mode_upper_case(mode, tmp_path):
+    cache_dir = tmp_path / ".statue"
+    configuration = ConfigurationBuilder.from_dict(
+        cache_dir=cache_dir, statue_config_dict={GENERAL: {MODE: mode.name.upper()}}
     )
 
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.commands_repository) == 0
     assert len(configuration.sources_repository) == 0
+    assert configuration.cache.cache_root_directory == cache_dir
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert configuration.default_mode == mode
 
 
 @parametrize(argnames="mode", argvalues=[RunnerMode.SYNC, RunnerMode.ASYNC])
-def test_configuration_builder_update_mode_lower_case(mode):
-    configuration = Configuration()
-
-    ConfigurationBuilder.update_from_config(
-        configuration=configuration, statue_config={GENERAL: {MODE: mode.name.lower()}}
+def test_configuration_builder_from_dict_mode_lower_case(mode, tmp_path):
+    cache_dir = tmp_path / ".statue"
+    configuration = ConfigurationBuilder.from_dict(
+        cache_dir=cache_dir, statue_config_dict={GENERAL: {MODE: mode.name.lower()}}
     )
 
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.commands_repository) == 0
     assert len(configuration.sources_repository) == 0
+    assert configuration.cache.cache_root_directory == cache_dir
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert configuration.default_mode == mode
 
 
-def test_configuration_builder_update_contexts():
-    configuration = Configuration()
+def test_configuration_builder_from_dict_update_contexts(tmp_path):
     contexts_config = mock.Mock()
+    cache_dir = tmp_path / ".statue"
 
     with mock.patch.object(
-        configuration.contexts_repository, "update_from_config"
+        ContextsRepository, "update_from_config"
     ) as contexts_update_mock:
-        ConfigurationBuilder.update_from_config(
-            configuration=configuration, statue_config={CONTEXTS: contexts_config}
+        configuration = ConfigurationBuilder.from_dict(
+            cache_dir=cache_dir, statue_config_dict={CONTEXTS: contexts_config}
         )
         contexts_update_mock.assert_called_once_with(contexts_config)
 
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.commands_repository) == 0
     assert len(configuration.sources_repository) == 0
+    assert configuration.cache.cache_root_directory == cache_dir
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert configuration.default_mode == RunnerMode.SYNC
 
 
-def test_configuration_builder_update_commands():
-    configuration = Configuration()
+def test_configuration_builder_from_dict_update_commands(tmp_path):
     commands_config = mock.Mock()
+    cache_dir = tmp_path / ".statue"
 
     with mock.patch.object(
-        configuration.commands_repository, "update_from_config"
+        CommandsRepository, "update_from_config"
     ) as commands_update_mock:
-        ConfigurationBuilder.update_from_config(
-            configuration=configuration, statue_config={COMMANDS: commands_config}
+        configuration = ConfigurationBuilder.from_dict(
+            cache_dir=cache_dir, statue_config_dict={COMMANDS: commands_config}
         )
         commands_update_mock.assert_called_once_with(commands_config)
 
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.commands_repository) == 0
     assert len(configuration.sources_repository) == 0
+    assert configuration.cache.cache_root_directory == cache_dir
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert configuration.default_mode == RunnerMode.SYNC
 
 
-def test_configuration_builder_update_sources():
-    configuration = Configuration()
+def test_configuration_builder_from_dict_update_sources(tmp_path):
     sources_config = mock.Mock()
+    cache_dir = tmp_path / ".statue"
 
     with mock.patch.object(
-        configuration.sources_repository, "update_from_config"
+        SourcesRepository, "update_from_config"
     ) as sources_update_mock:
-        ConfigurationBuilder.update_from_config(
-            configuration=configuration, statue_config={SOURCES: sources_config}
+        configuration = ConfigurationBuilder.from_dict(
+            cache_dir=cache_dir, statue_config_dict={SOURCES: sources_config}
         )
         sources_update_mock.assert_called_once_with(
             config=sources_config, contexts_repository=configuration.contexts_repository
@@ -104,15 +122,16 @@ def test_configuration_builder_update_sources():
     assert len(configuration.contexts_repository) == 0
     assert len(configuration.commands_repository) == 0
     assert len(configuration.sources_repository) == 0
+    assert configuration.cache.cache_root_directory == cache_dir
+    assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert configuration.default_mode == RunnerMode.SYNC
 
 
-def test_configuration_builder_update_fail_update_mode():
-    configuration = Configuration()
-
+def test_configuration_builder_from_dict_fail_update_mode(tmp_path):
+    cache_dir = tmp_path / ".statue"
     with pytest.raises(
         InvalidConfiguration, match="^Got unexpected runner mode in configuration: BLA$"
     ):
-        ConfigurationBuilder.update_from_config(
-            configuration=configuration, statue_config={GENERAL: {MODE: "bla"}}
+        ConfigurationBuilder.from_dict(
+            cache_dir=cache_dir, statue_config_dict={GENERAL: {MODE: "bla"}}
         )

--- a/tests/configuration/configuration_builder/test_configuration_builder_update_from_config.py
+++ b/tests/configuration/configuration_builder/test_configuration_builder_update_from_config.py
@@ -1,3 +1,4 @@
+import random
 from unittest import mock
 
 import pytest
@@ -13,6 +14,7 @@ from statue.constants import (
     CONTEXTS,
     DEFAULT_HISTORY_SIZE,
     GENERAL,
+    HISTORY_SIZE,
     MODE,
     SOURCES,
 )
@@ -63,6 +65,21 @@ def test_configuration_builder_from_dict_mode_lower_case(mode, tmp_path):
     assert configuration.cache.cache_root_directory == cache_dir
     assert configuration.cache.history_size == DEFAULT_HISTORY_SIZE
     assert configuration.default_mode == mode
+
+
+def test_configuration_builder_from_dict_history_size(tmp_path):
+    cache_dir = tmp_path / ".statue"
+    size = random.randint(1, 100)
+    configuration = ConfigurationBuilder.from_dict(
+        cache_dir=cache_dir, statue_config_dict={GENERAL: {HISTORY_SIZE: size}}
+    )
+
+    assert len(configuration.contexts_repository) == 0
+    assert len(configuration.commands_repository) == 0
+    assert len(configuration.sources_repository) == 0
+    assert configuration.cache.cache_root_directory == cache_dir
+    assert configuration.cache.history_size == size
+    assert configuration.default_mode == RunnerMode.SYNC
 
 
 def test_configuration_builder_from_dict_update_contexts(tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,11 +40,6 @@ def mock_tqdm_range(mocker):
 
 
 @pytest.fixture
-def mock_update_from_config(mocker):
-    return mocker.patch.object(ConfigurationBuilder, "update_from_config")
-
-
-@pytest.fixture
 def mock_configuration_path(mocker, tmp_path):
     dummy_path = tmp_path / "bla.toml"
     configuration_path_mock = mocker.patch.object(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 import os
+import random
 from pathlib import Path
 
 import mock
 import pytest
 
+from statue.cache import Cache
 from statue.config.commands_repository import CommandsRepository
 from statue.config.configuration import Configuration
 from statue.config.configuration_builder import ConfigurationBuilder
@@ -56,10 +58,11 @@ def mock_cache_path(mocker, tmp_path):
 
 @pytest.fixture
 def mock_build_configuration_from_file(mocker):
+    history_size = random.randint(1, 100)
     builder_mock = mocker.patch.object(
         ConfigurationBuilder, "build_configuration_from_file"
     )
-    builder_mock.return_value = Configuration()
+    builder_mock.return_value = Configuration(cache=Cache(size=history_size))
     builder_mock.return_value.cache = mock.Mock()
     builder_mock.return_value.build_commands = mock.Mock()
     builder_mock.return_value.build_commands_map = mock.Mock()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_cases import parametrize
 
 from statue.cache import Cache
-from statue.constants import HISTORY_SIZE
+from statue.constants import DEFAULT_HISTORY_SIZE
 from statue.exceptions import CacheError
 
 
@@ -106,7 +106,7 @@ def test_save_evaluation_deletes_old_evaluations(tmp_path, mock_time):
     evaluations_dir = cache_dir / "evaluations"
     evaluations_dir.mkdir(parents=True)
 
-    time_stamps = list(random.choices(range(1_000_000), k=HISTORY_SIZE + 1))
+    time_stamps = list(random.choices(range(1_000_000), k=DEFAULT_HISTORY_SIZE + 1))
     time_stamps.sort(reverse=True)
     old_time_stamps, recent_time_stamp = time_stamps[1:], time_stamps[0]
     old_evaluations = [


### PR DESCRIPTION
**Description**
One can now set history size in configuration using the command `statue config set-history-size`

**Tests**
Added relevant unit tests and ran `statue config set-history-size` to see it works.

**Alternatives**
Not relevant.

**Additional context**
Python 3.9, Windows