### PR TITLE
Avoid context circular parenting

### DIFF
--- a/src/statue/context.py
+++ b/src/statue/context.py
@@ -1,13 +1,11 @@
 """Context class used for reading commands in various contexts."""
 from collections import OrderedDict
-from dataclasses import dataclass, field
-from typing import Any, List, MutableMapping, Optional
+from typing import Any, Iterable, List, MutableMapping, Optional
 from typing import OrderedDict as OrderedDictType
 
 from statue.constants import ALIASES, ALLOWED_BY_DEFAULT, HELP, PARENT
 
 
-@dataclass
 class Context:
     """
     Class representing a command context.
@@ -16,11 +14,68 @@ class Context:
     command arguments according to the context you are using. For ex
     """
 
-    name: str
-    help: str
-    aliases: List[str] = field(default_factory=list)
-    parent: Optional["Context"] = field(default=None)
-    allowed_by_default: bool = field(default=False)
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        name: str,
+        help: str,  # pylint: disable=redefined-builtin
+        aliases: Optional[Iterable[str]] = None,
+        parent: Optional["Context"] = None,
+        allowed_by_default: bool = False,
+    ):
+        """
+        Context constructor.
+
+        :param name: Name of the context
+        :type name: str
+        :param help: Short help string to describe context
+        :type help: str
+        :param aliases: List of possible aliases of the context
+        :type aliases: Optional[Iterable[str]]
+        :param parent: Optional parent context for this context
+        :type parent: Optional[Context]
+        :param allowed_by_default: Allow this context for all commands by default
+        :type allowed_by_default: bool
+        """
+        self.name = name
+        self.help = help
+        self.aliases = list(aliases) if aliases is not None else []
+        self.parent = parent
+        self.allowed_by_default = allowed_by_default
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Check equality between two contexts.
+
+        :param other: other object to compare to
+        :type other: object
+        :return: are contexts equal
+        :rtype: bool
+        """
+        return (
+            isinstance(other, Context)
+            and self.name == other.name
+            and self.help == other.help
+            and self.aliases == other.aliases
+            and self.parent == other.parent
+            and self.allowed_by_default == other.allowed_by_default
+        )
+
+    def __repr__(self) -> str:
+        """
+        String representation of the context.
+
+        :return: context as string
+        :rtype: str
+        """
+        return (
+            "Context("
+            f"name='{self.name}', "
+            f"help='{self.help}', "
+            f"aliases={self.aliases}, "
+            f"parent={self.parent}, "
+            f"allowed_by_default={self.allowed_by_default}"
+            ")"
+        )
 
     def __hash__(self) -> int:
         """

--- a/src/statue/exceptions.py
+++ b/src/statue/exceptions.py
@@ -65,7 +65,7 @@ class CommandExecutionError(StatueException):
         )
 
 
-# Other exceptions
+# Context related exceptions
 
 
 class UnknownContext(StatueException):
@@ -81,6 +81,26 @@ class UnknownContext(StatueException):
         super().__init__(f'Could not find context named "{context_name}"')
 
 
+class ContextCircularParentingError(StatueException):
+    """Parent cannot be a child of its child."""
+
+    def __init__(self, context1: str, context2: str):
+        """
+        Exception constructor.
+
+        :param context1: Name of first context
+        :type context1: str
+        :param context2: Name of second context
+        :type context2: str
+        """
+        super().__init__(
+            "Cannot set circular parenting between " f'"{context1}" and "{context2}"'
+        )
+
+
+# Template related exceptions
+
+
 class UnknownTemplate(StatueException):
     """Template isn't recognized."""
 
@@ -92,6 +112,9 @@ class UnknownTemplate(StatueException):
         :type template_name: str
         """
         super().__init__(f'Could not find template named "{template_name}"')
+
+
+# Cache related exceptions
 
 
 class CacheError(StatueException):

--- a/tests/context/test_context_basics.py
+++ b/tests/context/test_context_basics.py
@@ -12,11 +12,20 @@ def test_context_default_constructor():
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
 
     assert context.name == CONTEXT1
-    assert context.aliases == []
+    assert not context.aliases
     assert context.all_names == [CONTEXT1]
     assert context.help == CONTEXT_HELP_STRING1
     assert context.parent is None
     assert not context.allowed_by_default
+    assert str(context) == (
+        "Context("
+        f"name='{CONTEXT1}', "
+        f"help='{CONTEXT_HELP_STRING1}', "
+        "aliases=[], "
+        "parent=None, "
+        "allowed_by_default=False"
+        ")"
+    )
 
 
 def test_context_constructor_with_aliases():
@@ -30,6 +39,15 @@ def test_context_constructor_with_aliases():
     assert context.help == CONTEXT_HELP_STRING1
     assert context.parent is None
     assert not context.allowed_by_default
+    assert str(context) == (
+        "Context("
+        f"name='{CONTEXT1}', "
+        f"help='{CONTEXT_HELP_STRING1}', "
+        f"aliases=['{CONTEXT2}', '{CONTEXT3}'], "
+        "parent=None, "
+        "allowed_by_default=False"
+        ")"
+    )
 
 
 def test_context_constructor_with_parent():
@@ -37,22 +55,51 @@ def test_context_constructor_with_parent():
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent)
 
     assert context.name == CONTEXT1
-    assert context.aliases == []
+    assert not context.aliases
     assert context.all_names == [CONTEXT1]
     assert context.help == CONTEXT_HELP_STRING1
     assert context.parent == parent
     assert not context.allowed_by_default
+
+    parent_str = str(parent)
+    assert parent_str == (
+        "Context("
+        f"name='{CONTEXT2}', "
+        f"help='{CONTEXT_HELP_STRING2}', "
+        "aliases=[], "
+        f"parent=None, "
+        "allowed_by_default=False"
+        ")"
+    )
+    assert str(context) == (
+        "Context("
+        f"name='{CONTEXT1}', "
+        f"help='{CONTEXT_HELP_STRING1}', "
+        "aliases=[], "
+        f"parent={parent_str}, "
+        "allowed_by_default=False"
+        ")"
+    )
 
 
 def test_context_constructor_allowed_by_default():
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=True)
 
     assert context.name == CONTEXT1
-    assert context.aliases == []
+    assert not context.aliases
     assert context.all_names == [CONTEXT1]
     assert context.help == CONTEXT_HELP_STRING1
     assert context.parent is None
     assert context.allowed_by_default
+    assert str(context) == (
+        "Context("
+        f"name='{CONTEXT1}', "
+        f"help='{CONTEXT_HELP_STRING1}', "
+        "aliases=[], "
+        f"parent=None, "
+        "allowed_by_default=True"
+        ")"
+    )
 
 
 def test_context_clear_aliases():
@@ -62,8 +109,17 @@ def test_context_clear_aliases():
     context.clear_aliases()
 
     assert context.name == CONTEXT1
-    assert context.aliases == []
+    assert not context.aliases
     assert context.all_names == [CONTEXT1]
     assert context.help == CONTEXT_HELP_STRING1
     assert context.parent is None
     assert not context.allowed_by_default
+    assert str(context) == (
+        "Context("
+        f"name='{CONTEXT1}', "
+        f"help='{CONTEXT_HELP_STRING1}', "
+        "aliases=[], "
+        f"parent=None, "
+        "allowed_by_default=False"
+        ")"
+    )

--- a/tests/context/test_context_basics.py
+++ b/tests/context/test_context_basics.py
@@ -1,10 +1,14 @@
+import pytest
+
 from statue.context import Context
+from statue.exceptions import ContextCircularParentingError
 from tests.constants import (
     CONTEXT1,
     CONTEXT2,
     CONTEXT3,
     CONTEXT_HELP_STRING1,
     CONTEXT_HELP_STRING2,
+    CONTEXT_HELP_STRING3,
 )
 
 
@@ -16,6 +20,7 @@ def test_context_default_constructor():
     assert context.all_names == [CONTEXT1]
     assert context.help == CONTEXT_HELP_STRING1
     assert context.parent is None
+    assert context.parents == []
     assert not context.allowed_by_default
     assert str(context) == (
         "Context("
@@ -38,6 +43,7 @@ def test_context_constructor_with_aliases():
     assert context.all_names == [CONTEXT1, CONTEXT2, CONTEXT3]
     assert context.help == CONTEXT_HELP_STRING1
     assert context.parent is None
+    assert context.parents == []
     assert not context.allowed_by_default
     assert str(context) == (
         "Context("
@@ -59,6 +65,7 @@ def test_context_constructor_with_parent():
     assert context.all_names == [CONTEXT1]
     assert context.help == CONTEXT_HELP_STRING1
     assert context.parent == parent
+    assert context.parents == [parent]
     assert not context.allowed_by_default
 
     parent_str = str(parent)
@@ -68,6 +75,49 @@ def test_context_constructor_with_parent():
         f"help='{CONTEXT_HELP_STRING2}', "
         "aliases=[], "
         f"parent=None, "
+        "allowed_by_default=False"
+        ")"
+    )
+    assert str(context) == (
+        "Context("
+        f"name='{CONTEXT1}', "
+        f"help='{CONTEXT_HELP_STRING1}', "
+        "aliases=[], "
+        f"parent={parent_str}, "
+        "allowed_by_default=False"
+        ")"
+    )
+
+
+def test_context_constructor_with_grandparent():
+    grandparent = Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3)
+    parent = Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2, parent=grandparent)
+    context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent)
+
+    assert context.name == CONTEXT1
+    assert not context.aliases
+    assert context.all_names == [CONTEXT1]
+    assert context.help == CONTEXT_HELP_STRING1
+    assert context.parent == parent
+    assert context.parents == [parent, grandparent]
+    assert not context.allowed_by_default
+
+    grandparent_str, parent_str = str(grandparent), str(parent)
+    assert grandparent_str == (
+        "Context("
+        f"name='{CONTEXT3}', "
+        f"help='{CONTEXT_HELP_STRING3}', "
+        "aliases=[], "
+        f"parent=None, "
+        "allowed_by_default=False"
+        ")"
+    )
+    assert parent_str == (
+        "Context("
+        f"name='{CONTEXT2}', "
+        f"help='{CONTEXT_HELP_STRING2}', "
+        "aliases=[], "
+        f"parent={grandparent_str}, "
         "allowed_by_default=False"
         ")"
     )
@@ -123,3 +173,26 @@ def test_context_clear_aliases():
         "allowed_by_default=False"
         ")"
     )
+
+
+def test_context_cannot_set_circular_parenting():
+    parent = Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2)
+    context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent)
+
+    with pytest.raises(
+        ContextCircularParentingError,
+        match=f'^Cannot set circular parenting between "{CONTEXT2}" and "{CONTEXT1}"$',
+    ):
+        parent.parent = context
+
+
+def test_context_cannot_set_circular_grandparenting():
+    grandparent = Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3)
+    parent = Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2, parent=grandparent)
+    context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent)
+
+    with pytest.raises(
+        ContextCircularParentingError,
+        match=f'^Cannot set circular parenting between "{CONTEXT3}" and "{CONTEXT1}"$',
+    ):
+        grandparent.parent = context

--- a/tests/context/test_contexts_equality.py
+++ b/tests/context/test_contexts_equality.py
@@ -1,0 +1,113 @@
+from pytest_cases import THIS_MODULE, case, parametrize_with_cases
+
+from statue.context import Context
+from tests.constants import (
+    CONTEXT1,
+    CONTEXT2,
+    CONTEXT3,
+    CONTEXT_HELP_STRING1,
+    CONTEXT_HELP_STRING2,
+    CONTEXT_HELP_STRING3,
+)
+
+EQUAL_TAG = "equal"
+NOT_EQUAL_TAG = "not_equal"
+
+
+# Equal cases
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_simple():
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    return context1, context2
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_with_aliases():
+    context1 = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, aliases=[CONTEXT2, CONTEXT3]
+    )
+    context2 = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, aliases=[CONTEXT2, CONTEXT3]
+    )
+    return context1, context2
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_with_parents():
+    parent1 = Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2)
+    parent2 = Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2)
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent1)
+    context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent2)
+    return context1, context2
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_with_allow_by_default():
+    context1 = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=True
+    )
+    context2 = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=True
+    )
+    return context1, context2
+
+
+# Not equal cases
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_name():
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    context2 = Context(name=CONTEXT2, help=CONTEXT_HELP_STRING1)
+    return context1, context2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_help():
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING2)
+    return context1, context2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_aliases():
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, aliases=[CONTEXT2])
+    context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING2, aliases=[CONTEXT3])
+    return context1, context2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_with_different_parents():
+    parent1 = Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2)
+    parent2 = Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3)
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent1)
+    context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent2)
+    return context1, context2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_with_different_allow_by_default():
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    context2 = Context(
+        name=CONTEXT1, help=CONTEXT_HELP_STRING1, allowed_by_default=True
+    )
+    return context1, context2
+
+
+@parametrize_with_cases(
+    argnames=["context1", "context2"], cases=THIS_MODULE, has_tag=EQUAL_TAG
+)
+def test_contexts_equality(context1, context2):
+    assert context1 == context2
+    assert not (context1 != context2)  # pylint: disable=superfluous-parens
+
+
+@parametrize_with_cases(
+    argnames=["context1", "context2"], cases=THIS_MODULE, has_tag=NOT_EQUAL_TAG
+)
+def test_contexts_non_equality(context1, context2):
+    assert context1 != context2
+    assert not (context1 == context2)  # pylint: disable=superfluous-parens


### PR DESCRIPTION
**Description**
`Context` objects now throw exception when trying to set circular parenting

**Tests**
Added relevant unit tests

**Alternatives**
Not handling these scenarios may cause infinite loops in *Statue*.
This problem must be handled.

**Additional context**
Python 3.9, Windows