### PR TITLE
Add contexts validations

### DIFF
--- a/src/statue/config/contexts_repository.py
+++ b/src/statue/config/contexts_repository.py
@@ -1,6 +1,7 @@
 """Place for saving all available contexts."""
+import itertools
 from collections import OrderedDict
-from typing import Any, Dict, Iterator
+from typing import Any, Dict, Iterator, List
 from typing import OrderedDict as OrderedDictType
 
 from statue.constants import ALIASES, ALLOWED_BY_DEFAULT, HELP, PARENT
@@ -66,11 +67,16 @@ class ContextsRepository:
         :return: does context exist in repository
         :rtype: bool
         """
-        try:
-            self[item]
-        except UnknownContext:
-            return False
-        return True
+        return item in self.occupied_names
+
+    @property
+    def occupied_names(self) -> List[str]:
+        """List of all occupied names in contexts repository."""
+        occupied_names = list(
+            itertools.chain.from_iterable([context.all_names for context in self])
+        )
+        occupied_names.sort()
+        return occupied_names
 
     def add_contexts(self, *contexts: Context):
         """

--- a/tests/configuration/contexts_repository/test_contexts_repository_basics.py
+++ b/tests/configuration/contexts_repository/test_contexts_repository_basics.py
@@ -24,6 +24,7 @@ def test_contexts_repository_simple_constructor():
     contexts_repository = ContextsRepository()
 
     assert len(contexts_repository) == 0
+    assert not contexts_repository.occupied_names
 
 
 def test_contexts_repository_with_one_simple_context():
@@ -34,6 +35,7 @@ def test_contexts_repository_with_one_simple_context():
     assert contexts_repository[CONTEXT1] == context
     assert CONTEXT1 in contexts_repository
     assert CONTEXT2 not in contexts_repository
+    assert contexts_repository.occupied_names == [CONTEXT1]
 
 
 def test_contexts_repository_with_three_simple_context():
@@ -50,6 +52,7 @@ def test_contexts_repository_with_three_simple_context():
     assert CONTEXT2 in contexts_repository
     assert CONTEXT3 in contexts_repository
     assert CONTEXT4 not in contexts_repository
+    assert contexts_repository.occupied_names == [CONTEXT1, CONTEXT2, CONTEXT3]
 
 
 def test_contexts_repository_with_one_context_with_aliases():
@@ -66,6 +69,7 @@ def test_contexts_repository_with_one_context_with_aliases():
     assert CONTEXT2 in contexts_repository
     assert CONTEXT3 in contexts_repository
     assert CONTEXT4 not in contexts_repository
+    assert contexts_repository.occupied_names == [CONTEXT1, CONTEXT2, CONTEXT3]
 
 
 def test_contexts_repository_with_one_context_with_parent():
@@ -80,6 +84,7 @@ def test_contexts_repository_with_one_context_with_parent():
     assert CONTEXT1 in contexts_repository
     assert CONTEXT2 in contexts_repository
     assert CONTEXT3 not in contexts_repository
+    assert contexts_repository.occupied_names == [CONTEXT1, CONTEXT2]
 
 
 def test_contexts_repository_with_multiple_contexts():
@@ -103,6 +108,13 @@ def test_contexts_repository_with_multiple_contexts():
     assert CONTEXT3 in contexts_repository
     assert CONTEXT4 in contexts_repository
     assert CONTEXT5 in contexts_repository
+    assert contexts_repository.occupied_names == [
+        CONTEXT1,
+        CONTEXT2,
+        CONTEXT3,
+        CONTEXT4,
+        CONTEXT5,
+    ]
 
 
 def test_contexts_repository_reset():
@@ -119,6 +131,7 @@ def test_contexts_repository_reset():
 
     assert len(contexts_repository) == 0
     assert CONTEXT1 not in contexts_repository
+    assert not contexts_repository.occupied_names
 
 
 def test_contexts_repository_add_contexts():
@@ -140,6 +153,12 @@ def test_contexts_repository_add_contexts():
     assert CONTEXT2 in contexts_repository
     assert CONTEXT3 in contexts_repository
     assert CONTEXT4 in contexts_repository
+    assert contexts_repository.occupied_names == [
+        CONTEXT1,
+        CONTEXT2,
+        CONTEXT3,
+        CONTEXT4,
+    ]
 
 
 def test_contexts_repository_iterate():
@@ -163,6 +182,7 @@ def test_contexts_repository_remove_context():
     assert CONTEXT1 in contexts_repository
     assert CONTEXT2 not in contexts_repository
     assert CONTEXT3 in contexts_repository
+    assert contexts_repository.occupied_names == [CONTEXT1, CONTEXT3]
 
 
 def test_contexts_repository_as_dict():


### PR DESCRIPTION
**Description**
Raise exception when using `ContextsRepository.add_contexts()` with pre-existing context names or with contexts with the same name.
This is done with a fallback so the addition doesn't occur when inconsistency is found

**Tests**
Added relevant unit tests.

**Alternatives**
Not relevant.

**Additional context**
Python 3.9, Windows