### PR TITLE
Command filter saves contexts in list

### DIFF
--- a/src/statue/commands_filter.py
+++ b/src/statue/commands_filter.py
@@ -41,17 +41,17 @@ class CommandsFilter:
             )
 
     @property
-    def contexts(self):
+    def contexts(self) -> FrozenSet[Context]:
         """Filter contexts."""
         return self._contexts
 
     @property
-    def allowed_commands(self):
+    def allowed_commands(self) -> Optional[FrozenSet[str]]:
         """Filter allowed commands."""
         return self._allowed_commands
 
     @property
-    def denied_commands(self):
+    def denied_commands(self) -> Optional[FrozenSet[str]]:
         """Filter denied commands."""
         return self._denied_commands
 

--- a/src/statue/commands_filter.py
+++ b/src/statue/commands_filter.py
@@ -13,7 +13,7 @@ class CommandsFilter:
 
     def __init__(
         self,
-        contexts: Optional[Collection[Context]] = None,
+        contexts: Optional[List[Context]] = None,
         allowed_commands: Optional[Collection[str]] = None,
         denied_commands: Optional[Collection[str]] = None,
     ):
@@ -28,7 +28,7 @@ class CommandsFilter:
         :type denied_commands: Optional[Collection[str]]
         :raises ValueError: Raised if both allowed and denied commands are set.
         """
-        self._contexts = frozenset() if contexts is None else frozenset(contexts)
+        self._contexts = [] if contexts is None else list(contexts)
         self._allowed_commands = (
             None if allowed_commands is None else frozenset(allowed_commands)
         )
@@ -41,9 +41,9 @@ class CommandsFilter:
             )
 
     @property
-    def contexts(self) -> FrozenSet[Context]:
+    def contexts(self) -> List[Context]:
         """Filter contexts."""
-        return self._contexts
+        return list(self._contexts)
 
     @property
     def allowed_commands(self) -> Optional[FrozenSet[str]]:
@@ -147,6 +147,9 @@ class CommandsFilter:
         """
         Merge two command filters into one filter.
 
+        PAY ATTENTION: the order of merge is important! evaluating contexts will be done
+        in their order
+
         :param filter1: First filter to be merged
         :type filter1: CommandsFilter
         :param filter2: Second filter to be merged
@@ -156,7 +159,7 @@ class CommandsFilter:
         :raises ValueError: Raised when a command is allowed in one filter
             and denied in another
         """
-        contexts = filter1.contexts.union(filter2.contexts)
+        contexts = filter1.contexts + filter2.contexts
         allowed_commands = cls._intersect_optional_sets(
             filter1.allowed_commands, filter2.allowed_commands
         )
@@ -173,7 +176,7 @@ class CommandsFilter:
                 )
             denied_commands = None
         return CommandsFilter(
-            contexts=frozenset(contexts),
+            contexts=contexts,
             allowed_commands=allowed_commands,
             denied_commands=denied_commands,
         )

--- a/src/statue/commands_filter.py
+++ b/src/statue/commands_filter.py
@@ -24,7 +24,7 @@ class CommandsFilter:
         :type contexts: Optional[Collection[Context]]
         :param allowed_commands: Allowed commands that pass filter
         :type allowed_commands: Optional[Collection[str]]
-        :param denied_commands: Denied commands that does not pass filter
+        :param denied_commands: Denied commands that do not pass filter
         :type denied_commands: Optional[Collection[str]]
         :raises ValueError: Raised if both allowed and denied commands are set.
         """

--- a/tests/commands_filter/test_commands_filter_basics.py
+++ b/tests/commands_filter/test_commands_filter_basics.py
@@ -18,16 +18,16 @@ from tests.constants import (
 def test_commands_filter_simple_constructor():
     commands_filter = CommandsFilter()
 
-    assert commands_filter.contexts == frozenset()
+    assert not commands_filter.contexts
     assert commands_filter.allowed_commands is None
     assert commands_filter.denied_commands is None
 
 
 def test_commands_filter_with_contexts():
-    contexts = {
+    contexts = [
         Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
         Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
-    }
+    ]
     commands_filter = CommandsFilter(contexts=contexts)
 
     assert commands_filter.contexts == contexts
@@ -39,7 +39,7 @@ def test_commands_filter_with_allowed_commands():
     allowed_commands = {COMMAND1, COMMAND2, COMMAND3}
     commands_filter = CommandsFilter(allowed_commands=allowed_commands)
 
-    assert commands_filter.contexts == frozenset()
+    assert not commands_filter.contexts
     assert commands_filter.allowed_commands == allowed_commands
     assert commands_filter.denied_commands is None
 
@@ -48,7 +48,7 @@ def test_commands_filter_with_denied_commands():
     denied_commands = {COMMAND1, COMMAND2, COMMAND3}
     commands_filter = CommandsFilter(denied_commands=denied_commands)
 
-    assert commands_filter.contexts == frozenset()
+    assert not commands_filter.contexts
     assert commands_filter.allowed_commands is None
     assert commands_filter.denied_commands == denied_commands
 
@@ -57,7 +57,7 @@ def test_commands_filter_repr_string():
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
     assert str(CommandsFilter(contexts=[context], allowed_commands=[COMMAND1])) == (
         "CommandsFilter("
-        f"contexts=frozenset({{{str(context)}}}), "
+        f"contexts=[{str(context)}], "
         f"allowed_commands=frozenset({{'{COMMAND1}'}}), "
         "denied_commands=None)"
     )
@@ -65,14 +65,14 @@ def test_commands_filter_repr_string():
 
 def test_commands_filter_contexts_cannot_be_overridden():
     commands_filter = CommandsFilter(
-        contexts={
+        contexts=[
             Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
             Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
-        }
+        ]
     )
 
     with pytest.raises(AttributeError, match="^can't set attribute"):
-        commands_filter.contexts = {Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3)}
+        commands_filter.contexts = [Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3)]
 
 
 def test_commands_filter_allowed_commands_cannot_be_overridden():

--- a/tests/commands_filter/test_commands_filter_merge.py
+++ b/tests/commands_filter/test_commands_filter_merge.py
@@ -23,10 +23,10 @@ def case_empty_filters():
 
 def case_merge_contexts_with_nothing():
     filter1 = CommandsFilter(
-        contexts={
+        contexts=[
             Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
             Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
-        },
+        ],
         allowed_commands={COMMAND1, COMMAND2},
     )
     return filter1, CommandsFilter(), filter1
@@ -34,20 +34,38 @@ def case_merge_contexts_with_nothing():
 
 def case_merge_contexts_lists():
     filter1 = CommandsFilter(
-        contexts={
+        contexts=[
             Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
             Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
-        },
+        ],
     )
     filter2 = CommandsFilter(
-        contexts={Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3)},
+        contexts=[Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3)],
     )
     result = CommandsFilter(
-        contexts={
+        contexts=[
             Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
             Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
             Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
-        },
+        ],
+    )
+    return filter1, filter2, result
+
+
+def case_merge_contexts_lists_with_duplication():
+    context1, context2, context3 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+        Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+    )
+    filter1 = CommandsFilter(
+        contexts=[context1, context2],
+    )
+    filter2 = CommandsFilter(
+        contexts=[context3, context1],
+    )
+    result = CommandsFilter(
+        contexts=[context1, context2, context3, context1],
     )
     return filter1, filter2, result
 
@@ -87,8 +105,7 @@ def case_merge_allowed_and_denied_lists():
 def test_commands_filter_merge(
     filter1: CommandsFilter, filter2: CommandsFilter, result: CommandsFilter
 ):
-    assert result == CommandsFilter.merge(filter1, filter2)
-    assert result == CommandsFilter.merge(filter2, filter1)
+    assert CommandsFilter.merge(filter1, filter2) == result
 
 
 def test_command_filter_merge_fail_on_command_both_allowed_and_denied():

--- a/tests/configuration/configuration/test_configuration_build_commands_map.py
+++ b/tests/configuration/configuration/test_configuration_build_commands_map.py
@@ -173,7 +173,7 @@ def test_get_commands_map_with_source_context(mock_build_commands):
             call(
                 CommandsFilter(
                     denied_commands=[COMMAND3],
-                    contexts=[context1, context2],
+                    contexts=[context2, context1],
                 )
             ),
             call(


### PR DESCRIPTION
**Description**
When a `CommandBuilder` is set both two context specifications, one of `args` and one of `add_args`, the order in which we update the arguments is important and is not invariant for order change.

Therefore, `CommandsFilter` must save those contexts in the order of receiving them.  This means that source-specific contexts will be added after the global contexts given by the user, and will be taken into account afterwards.

**Tests**
Fixed relevant unit tests and ran `statue run` with multiple contexts.

**Alternatives**
When a cumulative context specification (such as `add_args`) is merged with non-cumulative context specification (such as `args` and `clear_args`) we can drop the command and build it. In my opinion, source specified are more important than global contexts and therefore they should override the global context.

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
