### PR TITLE
Pylint docs specification

### DIFF
--- a/src/statue/templates/default_templates/defaults.toml
+++ b/src/statue/templates/default_templates/defaults.toml
@@ -131,6 +131,13 @@ allowed_contexts = [
     "documentation",
 ]
 
+[commands.pylint.documentation]
+args = [
+    "--ignore-imports=y",
+    "--disable=all",
+    "--enable=C0115,C0304,C0116,C0114"
+]
+
 [commands.pylint.test]
 add_args = [
     "--disable=C0103,C0114,C0115,C0116,C0203,C0204,C0330,C0411",

--- a/statue.toml
+++ b/statue.toml
@@ -143,6 +143,13 @@ allowed_contexts = [
 ]
 version = "2.13.3"
 
+[commands.pylint.documentation]
+args = [
+    "--ignore-imports=y",
+    "--disable=all",
+    "--enable=C0115,C0304,C0116,C0114",
+]
+
 [commands.pylint.test]
 add_args = [
     "--disable=C0103,C0114,C0115,C0116,C0203,C0204,C0330,C0411",


### PR DESCRIPTION
**Description**
Added *Pylint* specification for the documentation specification. This is done in order to reduce the running duration when using the `-c docs` directive.

**Tests**
Ran it.

**Alternatives**
Not relevant

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial: