### PR TITLE
Fix unstable test

### DIFF
--- a/tests/cache/test_cache_save_evaluation.py
+++ b/tests/cache/test_cache_save_evaluation.py
@@ -34,7 +34,7 @@ def test_save_evaluation_deletes_old_evaluations(tmp_path, mock_time):
     evaluations_dir = cache_dir / "evaluations"
     evaluations_dir.mkdir(parents=True)
 
-    time_stamps = list(random.choices(range(1_000_000), k=size + 1))
+    time_stamps = list(random.sample(range(1_000_000), k=size + 1))
     time_stamps.sort(reverse=True)
     old_time_stamps, recent_time_stamp = time_stamps[1:], time_stamps[0]
     old_evaluations = [


### PR DESCRIPTION
**Description**
Use `random.sample` instead of `random.choice` in unit tests in order to avoid unstable unit test

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
