### PR TITLE
Pylint avoid symbolic disabling

### DIFF
--- a/src/statue/__main__.py
+++ b/src/statue/__main__.py
@@ -1,5 +1,6 @@
 """Main of Statue."""
+# pylint: disable=no-value-for-parameter
 from statue.cli import statue_cli
 
 if __name__ == "__main__":
-    statue_cli()  # pylint: disable=E1120
+    statue_cli()

--- a/src/statue/templates/default_templates/defaults.toml
+++ b/src/statue/templates/default_templates/defaults.toml
@@ -124,8 +124,8 @@ help = "Python code linter"
 args = [
     "--ignore-imports=y",
     "--disable=bad-continuation",
-    "--enable=useless-suppression",
-    "--fail-on=useless-suppression",
+    "--enable=useless-suppression,use-symbolic-message-instead",
+    "--fail-on=useless-suppression,use-symbolic-message-instead",
 ]
 allowed_contexts = [
     "documentation",

--- a/statue.toml
+++ b/statue.toml
@@ -135,8 +135,8 @@ help = "Python code linter"
 args = [
     "--ignore-imports=y",
     "--disable=bad-continuation",
-    "--enable=useless-suppression",
-    "--fail-on=useless-suppression",
+    "--enable=useless-suppression,use-symbolic-message-instead",
+    "--fail-on=useless-suppression,use-symbolic-message-instead",
 ]
 allowed_contexts = [
     "documentation",

--- a/tests/configuration/commands_repository/test_commands_repository_basics.py
+++ b/tests/configuration/commands_repository/test_commands_repository_basics.py
@@ -173,4 +173,4 @@ def test_commands_repository_get_non_existing_command():
     with pytest.raises(
         UnknownCommand, match=f'^Could not find command named "{COMMAND3}"$'
     ):
-        commands_repository[COMMAND3]  # pylint: disable=W0104
+        commands_repository[COMMAND3]  # pylint: disable=pointless-statement

--- a/tests/configuration/contexts_repository/test_contexts_repository_basics.py
+++ b/tests/configuration/contexts_repository/test_contexts_repository_basics.py
@@ -208,7 +208,7 @@ def test_contexts_repository_fail_getting_unknown_context():
     with pytest.raises(
         UnknownContext, match=f'^Could not find context named "{CONTEXT3}"$'
     ):
-        contexts_repository[CONTEXT3]  # pylint: disable=W0104
+        contexts_repository[CONTEXT3]  # pylint: disable=pointless-statement
 
 
 def test_contexts_repository_fail_on_adding_context_with_existing_name():


### PR DESCRIPTION
**Description**
should not disable *Pylint* errors as codes.

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
