### PR TITLE
Add command builder checks

### DIFF
--- a/src/statue/cli/commands.py
+++ b/src/statue/cli/commands.py
@@ -63,6 +63,7 @@ def show_command_cli(
         required_contexts = [
             context.name for context in command_builder.required_contexts
         ]
+        required_contexts.sort()
         click.echo(
             f"{bullet_style('Required contexts')} - " f"{', '.join(required_contexts)}"
         )
@@ -70,6 +71,7 @@ def show_command_cli(
         allowed_contexts = [
             context.name for context in command_builder.allowed_contexts
         ]
+        allowed_contexts.sort()
         click.echo(
             f"{bullet_style('Allowed contexts')} - " f"{', '.join(allowed_contexts)}"
         )
@@ -77,6 +79,7 @@ def show_command_cli(
         specified_contexts = [
             context.name for context in command_builder.specified_contexts
         ]
+        specified_contexts.sort()
         click.echo(
             f"{bullet_style('Specified contexts')} - "
             f"{', '.join(specified_contexts)}"

--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -150,19 +150,90 @@ class ContextSpecification:
         return ContextSpecification(args=args, add_args=add_args, clear_args=clear_args)
 
 
-@dataclass
-class CommandBuilder:  # pylint: disable=too-many-public-methods
+class CommandBuilder:  # pylint: disable=too-many-public-methods,too-many-arguments
     """Command builder as specified in configuration."""
 
-    name: str
-    help: str
-    default_args: List[str] = field(default_factory=list)
-    version: Optional[str] = field(default=None)
-    required_contexts: List[Context] = field(default_factory=list)
-    allowed_contexts: List[Context] = field(default_factory=list)
-    contexts_specifications: Dict[Context, ContextSpecification] = field(
-        default_factory=dict
-    )
+    def __init__(
+        self,
+        name: str,
+        help: str,  # pylint: disable=redefined-builtin
+        default_args: Optional[List[str]] = None,
+        version: Optional[str] = None,
+        required_contexts: Optional[List[Context]] = None,
+        allowed_contexts: Optional[List[Context]] = None,
+        contexts_specifications: Optional[Dict[Context, ContextSpecification]] = None,
+    ):
+        """
+        Constructor.
+
+        :param name: Name of the command to be built by the builder
+        :type name str
+        :param help: Help string to describe the command
+        :type help: str
+        :param default_args: Optional default arguments to be added to the command
+        :type default_args: Optional[List[str]]
+        :param version: Optional version specification for the command builder
+        :type version: Optional[str]
+        :param required_contexts: Optional list of contexts required by
+            the command builder
+        :type required_contexts: Optional[List[Context]]
+        :param allowed_contexts: Optional list of contexts allowed for
+            the command builder
+        :type allowed_contexts: Optional[List[Context]]
+        :param contexts_specifications: Optional dictionary of contexts specification
+            for the command builder
+        :type contexts_specifications: Optional[Dict[Context, ContextSpecification]]
+        """
+        self.name = name
+        self.help = help
+        self.default_args = default_args if default_args is not None else []
+        self.version = version
+        self.required_contexts = (
+            required_contexts if required_contexts is not None else []
+        )
+        self.allowed_contexts = allowed_contexts if allowed_contexts is not None else []
+        self.contexts_specifications = (
+            contexts_specifications if contexts_specifications is not None else {}
+        )
+
+    def __repr__(self) -> str:
+        """
+        Represent context as string.
+
+        :return: String representation of command builder
+        :rtype: str
+        """
+        return (
+            "CommandBuilder("
+            f"name={self.name}, "
+            f"help={self.help}, "
+            f"default_args={self.default_args}, "
+            f"version={self.version}, "
+            f"required_contexts={self.required_contexts}, "
+            f"allowed_contexts={self.allowed_contexts}, "
+            f"contexts_specifications={self.contexts_specifications}"
+            ")"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Check equality of this command builder with other object.
+
+        :param other: Object to compare to
+        :type other: object
+        :return: is equal to self
+        :rtype: bool
+        """
+        return (
+            isinstance(other, CommandBuilder)
+            and self.name == other.name
+            and self.help == other.help
+            and self.default_args == other.default_args
+            and self.version == other.version
+            and self.allowed_contexts == other.allowed_contexts
+            and self.required_contexts == other.required_contexts
+            and self.contexts_specifications == other.contexts_specifications
+        )
 
     @property
     def install_name(self) -> str:

--- a/src/statue/templates/default_templates/defaults.toml
+++ b/src/statue/templates/default_templates/defaults.toml
@@ -36,7 +36,6 @@ required_contexts = [
 ]
 allowed_contexts = [
     "fast",
-    "format",
     "test",
 ]
 
@@ -126,9 +125,6 @@ args = [
     "--disable=bad-continuation",
     "--enable=useless-suppression,use-symbolic-message-instead",
     "--fail-on=useless-suppression,use-symbolic-message-instead",
-]
-allowed_contexts = [
-    "documentation",
 ]
 
 [commands.pylint.documentation]

--- a/statue.toml
+++ b/statue.toml
@@ -37,7 +37,6 @@ required_contexts = [
 ]
 allowed_contexts = [
     "fast",
-    "format",
     "test",
 ]
 version = "1.4"
@@ -137,9 +136,6 @@ args = [
     "--disable=bad-continuation",
     "--enable=useless-suppression,use-symbolic-message-instead",
     "--fail-on=useless-suppression,use-symbolic-message-instead",
-]
-allowed_contexts = [
-    "documentation",
 ]
 version = "2.13.3"
 

--- a/tests/command_builder/test_command_builder_basics.py
+++ b/tests/command_builder/test_command_builder_basics.py
@@ -31,8 +31,8 @@ def test_command_builder_empty_constructor():
     assert command_builder.contexts_specifications == {}
     assert str(command_builder) == (
         "CommandBuilder("
-        f"name='{COMMAND1}', "
-        f"help='{COMMAND_HELP_STRING1}', "
+        f"name={COMMAND1}, "
+        f"help={COMMAND_HELP_STRING1}, "
         "default_args=[], "
         "version=None, "
         "required_contexts=[], "
@@ -60,10 +60,10 @@ def test_command_builder_with_version():
     assert command_builder.contexts_specifications == {}
     assert str(command_builder) == (
         "CommandBuilder("
-        f"name='{COMMAND1}', "
-        f"help='{COMMAND_HELP_STRING1}', "
+        f"name={COMMAND1}, "
+        f"help={COMMAND_HELP_STRING1}, "
         "default_args=[], "
-        f"version='{version}', "
+        f"version={version}, "
         "required_contexts=[], "
         "allowed_contexts=[], "
         "contexts_specifications={}"
@@ -88,8 +88,8 @@ def test_command_builder_with_default_args():
     assert command_builder.contexts_specifications == {}
     assert str(command_builder) == (
         "CommandBuilder("
-        f"name='{COMMAND1}', "
-        f"help='{COMMAND_HELP_STRING1}', "
+        f"name={COMMAND1}, "
+        f"help={COMMAND_HELP_STRING1}, "
         f"default_args=['{ARG1}', '{ARG2}'], "
         "version=None, "
         "required_contexts=[], "
@@ -116,8 +116,8 @@ def test_command_builder_with_required_contexts():
     assert command_builder.contexts_specifications == {}
     assert str(command_builder) == (
         "CommandBuilder("
-        f"name='{COMMAND1}', "
-        f"help='{COMMAND_HELP_STRING1}', "
+        f"name={COMMAND1}, "
+        f"help={COMMAND_HELP_STRING1}, "
         "default_args=[], "
         "version=None, "
         f"required_contexts=['{CONTEXT1}', '{CONTEXT2}'], "
@@ -144,8 +144,8 @@ def test_command_builder_with_allowed_contexts():
     assert command_builder.contexts_specifications == {}
     assert str(command_builder) == (
         "CommandBuilder("
-        f"name='{COMMAND1}', "
-        f"help='{COMMAND_HELP_STRING1}', "
+        f"name={COMMAND1}, "
+        f"help={COMMAND_HELP_STRING1}, "
         "default_args=[], "
         "version=None, "
         "required_contexts=[], "
@@ -184,8 +184,8 @@ def test_command_builder_with_specified_contexts():
     }
     assert str(command_builder) == (
         "CommandBuilder("
-        f"name='{COMMAND1}', "
-        f"help='{COMMAND_HELP_STRING1}', "
+        f"name={COMMAND1}, "
+        f"help={COMMAND_HELP_STRING1}, "
         "default_args=[], "
         "version=None, "
         "required_contexts=[], "
@@ -239,10 +239,10 @@ def test_command_builder_with_all_fields():
     }
     assert str(command_builder) == (
         "CommandBuilder("
-        f"name='{COMMAND1}', "
-        f"help='{COMMAND_HELP_STRING1}', "
+        f"name={COMMAND1}, "
+        f"help={COMMAND_HELP_STRING1}, "
         f"default_args=['{ARG1}', '{ARG2}'], "
-        f"version='{version}', "
+        f"version={version}, "
         f"required_contexts=['{CONTEXT1}', '{CONTEXT2}'], "
         f"allowed_contexts=['{CONTEXT3}', '{CONTEXT4}'], "
         "contexts_specifications={"

--- a/tests/command_builder/test_command_builder_basics.py
+++ b/tests/command_builder/test_command_builder_basics.py
@@ -1,5 +1,8 @@
+import pytest
+
 from statue.command_builder import CommandBuilder, ContextSpecification
 from statue.context import Context
+from statue.exceptions import InconsistentConfiguration
 from tests.constants import (
     ARG1,
     ARG2,
@@ -282,3 +285,63 @@ def test_command_builder_with_all_fields():
         "}"
         ")"
     )
+
+
+def test_command_builder_constructor_fail_with_both_allowed_and_required():
+    context1, context2 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+    )
+    with pytest.raises(
+        InconsistentConfiguration,
+        match=(
+            "^The following Contexts has been as set both allowed and required "
+            f"for {COMMAND1}: {CONTEXT1}$"
+        ),
+    ):
+        CommandBuilder(
+            name=COMMAND1,
+            help=COMMAND_HELP_STRING1,
+            allowed_contexts=[context1, context2],
+            required_contexts=[context1],
+        )
+
+
+def test_command_builder_constructor_fail_with_both_allowed_and_specified():
+    context1, context2 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+    )
+    with pytest.raises(
+        InconsistentConfiguration,
+        match=(
+            "^The following Contexts has been as set both allowed and specified "
+            f"for {COMMAND1}: {CONTEXT1}$"
+        ),
+    ):
+        CommandBuilder(
+            name=COMMAND1,
+            help=COMMAND_HELP_STRING1,
+            allowed_contexts=[context1, context2],
+            contexts_specifications={context1: ContextSpecification(args=[ARG1])},
+        )
+
+
+def test_command_builder_constructor_fail_with_both_required_and_specified():
+    context1, context2 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+    )
+    with pytest.raises(
+        InconsistentConfiguration,
+        match=(
+            "^The following Contexts has been as set both required and specified "
+            f"for {COMMAND1}: {CONTEXT1}$"
+        ),
+    ):
+        CommandBuilder(
+            name=COMMAND1,
+            help=COMMAND_HELP_STRING1,
+            required_contexts=[context1, context2],
+            contexts_specifications={context1: ContextSpecification(args=[ARG1])},
+        )

--- a/tests/command_builder/test_command_builder_basics.py
+++ b/tests/command_builder/test_command_builder_basics.py
@@ -29,6 +29,17 @@ def test_command_builder_empty_constructor():
     assert not command_builder.specified_contexts
     assert not command_builder.available_contexts
     assert command_builder.contexts_specifications == {}
+    assert str(command_builder) == (
+        "CommandBuilder("
+        f"name='{COMMAND1}', "
+        f"help='{COMMAND_HELP_STRING1}', "
+        "default_args=[], "
+        "version=None, "
+        "required_contexts=[], "
+        "allowed_contexts=[], "
+        "contexts_specifications={}"
+        ")"
+    )
 
 
 def test_command_builder_with_version():
@@ -47,6 +58,17 @@ def test_command_builder_with_version():
     assert not command_builder.specified_contexts
     assert not command_builder.available_contexts
     assert command_builder.contexts_specifications == {}
+    assert str(command_builder) == (
+        "CommandBuilder("
+        f"name='{COMMAND1}', "
+        f"help='{COMMAND_HELP_STRING1}', "
+        "default_args=[], "
+        f"version='{version}', "
+        "required_contexts=[], "
+        "allowed_contexts=[], "
+        "contexts_specifications={}"
+        ")"
+    )
 
 
 def test_command_builder_with_default_args():
@@ -64,6 +86,17 @@ def test_command_builder_with_default_args():
     assert not command_builder.specified_contexts
     assert not command_builder.available_contexts
     assert command_builder.contexts_specifications == {}
+    assert str(command_builder) == (
+        "CommandBuilder("
+        f"name='{COMMAND1}', "
+        f"help='{COMMAND_HELP_STRING1}', "
+        f"default_args=['{ARG1}', '{ARG2}'], "
+        "version=None, "
+        "required_contexts=[], "
+        "allowed_contexts=[], "
+        "contexts_specifications={}"
+        ")"
+    )
 
 
 def test_command_builder_with_required_contexts():
@@ -81,6 +114,17 @@ def test_command_builder_with_required_contexts():
     assert not command_builder.specified_contexts
     assert command_builder.available_contexts == [CONTEXT1, CONTEXT2]
     assert command_builder.contexts_specifications == {}
+    assert str(command_builder) == (
+        "CommandBuilder("
+        f"name='{COMMAND1}', "
+        f"help='{COMMAND_HELP_STRING1}', "
+        "default_args=[], "
+        "version=None, "
+        f"required_contexts=['{CONTEXT1}', '{CONTEXT2}'], "
+        "allowed_contexts=[], "
+        "contexts_specifications={}"
+        ")"
+    )
 
 
 def test_command_builder_with_allowed_contexts():
@@ -98,6 +142,17 @@ def test_command_builder_with_allowed_contexts():
     assert not command_builder.specified_contexts
     assert command_builder.available_contexts == [CONTEXT1, CONTEXT2]
     assert command_builder.contexts_specifications == {}
+    assert str(command_builder) == (
+        "CommandBuilder("
+        f"name='{COMMAND1}', "
+        f"help='{COMMAND_HELP_STRING1}', "
+        "default_args=[], "
+        "version=None, "
+        "required_contexts=[], "
+        f"allowed_contexts=['{CONTEXT1}', '{CONTEXT2}'], "
+        "contexts_specifications={}"
+        ")"
+    )
 
 
 def test_command_builder_with_specified_contexts():
@@ -127,6 +182,20 @@ def test_command_builder_with_specified_contexts():
         CONTEXT1: context_specification1,
         CONTEXT2: context_specification2,
     }
+    assert str(command_builder) == (
+        "CommandBuilder("
+        f"name='{COMMAND1}', "
+        f"help='{COMMAND_HELP_STRING1}', "
+        "default_args=[], "
+        "version=None, "
+        "required_contexts=[], "
+        "allowed_contexts=[], "
+        "contexts_specifications={"
+        f"'{CONTEXT1}': {str(context_specification1)}, "
+        f"'{CONTEXT2}': {str(context_specification2)}"
+        "}"
+        ")"
+    )
 
 
 def test_command_builder_with_all_fields():
@@ -168,3 +237,17 @@ def test_command_builder_with_all_fields():
         CONTEXT5: context_specification1,
         CONTEXT6: context_specification2,
     }
+    assert str(command_builder) == (
+        "CommandBuilder("
+        f"name='{COMMAND1}', "
+        f"help='{COMMAND_HELP_STRING1}', "
+        f"default_args=['{ARG1}', '{ARG2}'], "
+        f"version='{version}', "
+        f"required_contexts=['{CONTEXT1}', '{CONTEXT2}'], "
+        f"allowed_contexts=['{CONTEXT3}', '{CONTEXT4}'], "
+        "contexts_specifications={"
+        f"'{CONTEXT5}': {str(context_specification1)}, "
+        f"'{CONTEXT6}': {str(context_specification2)}"
+        "}"
+        ")"
+    )

--- a/tests/command_builder/test_command_builder_basics.py
+++ b/tests/command_builder/test_command_builder_basics.py
@@ -1,4 +1,5 @@
 from statue.command_builder import CommandBuilder, ContextSpecification
+from statue.context import Context
 from tests.constants import (
     ARG1,
     ARG2,
@@ -12,6 +13,12 @@ from tests.constants import (
     CONTEXT4,
     CONTEXT5,
     CONTEXT6,
+    CONTEXT_HELP_STRING1,
+    CONTEXT_HELP_STRING2,
+    CONTEXT_HELP_STRING3,
+    CONTEXT_HELP_STRING4,
+    CONTEXT_HELP_STRING5,
+    CONTEXT_HELP_STRING6,
 )
 from tests.util import dummy_version
 
@@ -100,8 +107,14 @@ def test_command_builder_with_default_args():
 
 
 def test_command_builder_with_required_contexts():
+    context1, context2 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+    )
     command_builder = CommandBuilder(
-        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[CONTEXT1, CONTEXT2]
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        required_contexts=[context1, context2],
     )
 
     assert command_builder.name == COMMAND1
@@ -109,10 +122,10 @@ def test_command_builder_with_required_contexts():
     assert command_builder.help == COMMAND_HELP_STRING1
     assert not command_builder.default_args
     assert command_builder.version is None
-    assert command_builder.required_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.required_contexts == {context1, context2}
     assert not command_builder.allowed_contexts
     assert not command_builder.specified_contexts
-    assert command_builder.available_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.available_contexts == {context1, context2}
     assert command_builder.contexts_specifications == {}
     assert str(command_builder) == (
         "CommandBuilder("
@@ -128,8 +141,14 @@ def test_command_builder_with_required_contexts():
 
 
 def test_command_builder_with_allowed_contexts():
+    context1, context2 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+    )
     command_builder = CommandBuilder(
-        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[CONTEXT1, CONTEXT2]
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        allowed_contexts=[context1, context2],
     )
 
     assert command_builder.name == COMMAND1
@@ -138,9 +157,9 @@ def test_command_builder_with_allowed_contexts():
     assert not command_builder.default_args
     assert command_builder.version is None
     assert not command_builder.required_contexts
-    assert command_builder.allowed_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.allowed_contexts == {context1, context2}
     assert not command_builder.specified_contexts
-    assert command_builder.available_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.available_contexts == {context1, context2}
     assert command_builder.contexts_specifications == {}
     assert str(command_builder) == (
         "CommandBuilder("
@@ -160,12 +179,16 @@ def test_command_builder_with_specified_contexts():
         ContextSpecification(args=[ARG1]),
         ContextSpecification(add_args=[ARG2]),
     )
+    context1, context2 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+    )
     command_builder = CommandBuilder(
         name=COMMAND1,
         help=COMMAND_HELP_STRING1,
         contexts_specifications={
-            CONTEXT1: context_specification1,
-            CONTEXT2: context_specification2,
+            context1: context_specification1,
+            context2: context_specification2,
         },
     )
 
@@ -176,11 +199,11 @@ def test_command_builder_with_specified_contexts():
     assert command_builder.version is None
     assert not command_builder.required_contexts
     assert not command_builder.allowed_contexts
-    assert command_builder.specified_contexts == [CONTEXT1, CONTEXT2]
-    assert command_builder.available_contexts == [CONTEXT1, CONTEXT2]
+    assert command_builder.specified_contexts == {context1, context2}
+    assert command_builder.available_contexts == {context1, context2}
     assert command_builder.contexts_specifications == {
-        CONTEXT1: context_specification1,
-        CONTEXT2: context_specification2,
+        context1: context_specification1,
+        context2: context_specification2,
     }
     assert str(command_builder) == (
         "CommandBuilder("
@@ -199,6 +222,14 @@ def test_command_builder_with_specified_contexts():
 
 
 def test_command_builder_with_all_fields():
+    context1, context2, context3, context4, context5, context6 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+        Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+        Context(name=CONTEXT4, help=CONTEXT_HELP_STRING4),
+        Context(name=CONTEXT5, help=CONTEXT_HELP_STRING5),
+        Context(name=CONTEXT6, help=CONTEXT_HELP_STRING6),
+    )
     context_specification1, context_specification2 = (
         ContextSpecification(args=[ARG3]),
         ContextSpecification(add_args=[ARG4]),
@@ -209,11 +240,11 @@ def test_command_builder_with_all_fields():
         help=COMMAND_HELP_STRING1,
         default_args=[ARG1, ARG2],
         version=version,
-        required_contexts=[CONTEXT1, CONTEXT2],
-        allowed_contexts=[CONTEXT3, CONTEXT4],
+        required_contexts=[context1, context2],
+        allowed_contexts=[context3, context4],
         contexts_specifications={
-            CONTEXT5: context_specification1,
-            CONTEXT6: context_specification2,
+            context5: context_specification1,
+            context6: context_specification2,
         },
     )
 
@@ -222,20 +253,20 @@ def test_command_builder_with_all_fields():
     assert command_builder.help == COMMAND_HELP_STRING1
     assert command_builder.default_args == [ARG1, ARG2]
     assert command_builder.version == version
-    assert command_builder.required_contexts == [CONTEXT1, CONTEXT2]
-    assert command_builder.allowed_contexts == [CONTEXT3, CONTEXT4]
-    assert command_builder.specified_contexts == [CONTEXT5, CONTEXT6]
-    assert command_builder.available_contexts == [
-        CONTEXT1,
-        CONTEXT2,
-        CONTEXT3,
-        CONTEXT4,
-        CONTEXT5,
-        CONTEXT6,
-    ]
+    assert command_builder.required_contexts == {context1, context2}
+    assert command_builder.allowed_contexts == {context3, context4}
+    assert command_builder.specified_contexts == {context5, context6}
+    assert command_builder.available_contexts == {
+        context1,
+        context2,
+        context3,
+        context4,
+        context5,
+        context6,
+    }
     assert command_builder.contexts_specifications == {
-        CONTEXT5: context_specification1,
-        CONTEXT6: context_specification2,
+        context5: context_specification1,
+        context6: context_specification2,
     }
     assert str(command_builder) == (
         "CommandBuilder("

--- a/tests/command_builder/test_command_builder_remove_context.py
+++ b/tests/command_builder/test_command_builder_remove_context.py
@@ -43,9 +43,9 @@ def test_command_builder_remove_required_context_by_name():
 
     command_builder.remove_context(context2)
 
-    assert command_builder.required_contexts == [context1]
-    assert command_builder.allowed_contexts == [context3, context4]
-    assert command_builder.specified_contexts == [context5, context6]
+    assert command_builder.required_contexts == {context1}
+    assert command_builder.allowed_contexts == {context3, context4}
+    assert command_builder.specified_contexts == {context5, context6}
 
 
 def test_command_builder_remove_allowed_context_by_name():
@@ -70,9 +70,9 @@ def test_command_builder_remove_allowed_context_by_name():
 
     command_builder.remove_context(context4)
 
-    assert command_builder.required_contexts == [context1, context2]
-    assert command_builder.allowed_contexts == [context3]
-    assert command_builder.specified_contexts == [context5, context6]
+    assert command_builder.required_contexts == {context1, context2}
+    assert command_builder.allowed_contexts == {context3}
+    assert command_builder.specified_contexts == {context5, context6}
 
 
 def test_command_builder_remove_specified_context_by_name():
@@ -97,6 +97,6 @@ def test_command_builder_remove_specified_context_by_name():
 
     command_builder.remove_context(context6)
 
-    assert command_builder.required_contexts == [context1, context2]
-    assert command_builder.allowed_contexts == [context3, context4]
-    assert command_builder.specified_contexts == [context5]
+    assert command_builder.required_contexts == {context1, context2}
+    assert command_builder.allowed_contexts == {context3, context4}
+    assert command_builder.specified_contexts == {context5}

--- a/tests/command_builder/test_command_builders_equality.py
+++ b/tests/command_builder/test_command_builders_equality.py
@@ -1,0 +1,188 @@
+from pytest_cases import THIS_MODULE, case, parametrize_with_cases
+
+from statue.command_builder import CommandBuilder, ContextSpecification
+from tests.constants import (
+    ARG1,
+    ARG2,
+    COMMAND1,
+    COMMAND2,
+    COMMAND_HELP_STRING1,
+    COMMAND_HELP_STRING2,
+    CONTEXT1,
+    CONTEXT2,
+)
+from tests.util import dummy_version
+
+EQUAL_TAG = "equal"
+NOT_EQUAL_TAG = "not_equal"
+
+
+# Equal cases
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_simple():
+    command_builder1 = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    command_builder2 = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    return command_builder1, command_builder2
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_with_default_args():
+    command_builder1 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, default_args=[ARG1, ARG2]
+    )
+    command_builder2 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, default_args=[ARG1, ARG2]
+    )
+    return command_builder1, command_builder2
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_with_version():
+    version = dummy_version()
+    command_builder1 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
+    )
+    command_builder2 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
+    )
+    return command_builder1, command_builder2
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_with_required_contexts():
+    command_builder1 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[CONTEXT1, CONTEXT2]
+    )
+    command_builder2 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[CONTEXT1, CONTEXT2]
+    )
+    return command_builder1, command_builder2
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_with_allowed_contexts():
+    command_builder1 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[CONTEXT1, CONTEXT2]
+    )
+    command_builder2 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[CONTEXT1, CONTEXT2]
+    )
+    return command_builder1, command_builder2
+
+
+@case(tags=[EQUAL_TAG])
+def case_equal_with_contexts_specifications():
+    command_builder1 = CommandBuilder(
+        name=CONTEXT1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={CONTEXT1: ContextSpecification(add_args=[ARG1])},
+    )
+    command_builder2 = CommandBuilder(
+        name=CONTEXT1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={CONTEXT1: ContextSpecification(add_args=[ARG1])},
+    )
+    return command_builder1, command_builder2
+
+
+# Not equal cases
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_name():
+    command_builder1 = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    command_builder2 = CommandBuilder(name=COMMAND2, help=COMMAND_HELP_STRING1)
+    return command_builder1, command_builder2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_help():
+    command_builder1 = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    command_builder2 = CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING2)
+    return command_builder1, command_builder2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_version():
+    version1, version2 = dummy_version(), dummy_version()
+    command_builder1 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, version=version1
+    )
+    command_builder2 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, version=version2
+    )
+    return command_builder1, command_builder2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_default_args():
+    command_builder1 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, default_args=[ARG1]
+    )
+    command_builder2 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, default_args=[ARG2]
+    )
+    return command_builder1, command_builder2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_allowed_contexts():
+    command_builder1 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[CONTEXT1]
+    )
+    command_builder2 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING2, allowed_contexts=[CONTEXT2]
+    )
+    return command_builder1, command_builder2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_different_required_contexts():
+    command_builder1 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[CONTEXT1]
+    )
+    command_builder2 = CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING2, required_contexts=[CONTEXT2]
+    )
+    return command_builder1, command_builder2
+
+
+@case(tags=[NOT_EQUAL_TAG])
+def case_not_equal_with_different_contexts_specifications():
+    command_builder1 = CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={CONTEXT1: ContextSpecification(add_args=[ARG1])},
+    )
+    command_builder2 = CommandBuilder(
+        name=CONTEXT1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={CONTEXT1: ContextSpecification(add_args=[ARG2])},
+    )
+    return command_builder1, command_builder2
+
+
+@parametrize_with_cases(
+    argnames=["command_builder1", "command_builder2"],
+    cases=THIS_MODULE,
+    has_tag=EQUAL_TAG,
+)
+def test_command_builders_equality(
+    command_builder1, command_builder2
+):  # pylint: disable=superfluous-parens
+    assert command_builder1 == command_builder2
+    assert not (command_builder1 != command_builder2)
+
+
+@parametrize_with_cases(
+    argnames=["command_builder1", "command_builder2"],
+    cases=THIS_MODULE,
+    has_tag=NOT_EQUAL_TAG,
+)
+def test_command_builders_non_equality(
+    command_builder1, command_builder2
+):  # pylint: disable=superfluous-parens
+    assert command_builder1 != command_builder2
+    assert not (command_builder1 == command_builder2)


### PR DESCRIPTION
**Description**
One defining a command in configuration, one should be able to define a context as only both required, allowed or specified. If a context is defined is two or more of them, an error should be raised

**Tests**
Added relevant unit tests and fixed configuration and template.

**Alternatives**
Ignore duplications.
Duplications are often a sign of confusion and unintentional settings. By avoiding duplications, we avoid this kind of mistakes.

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
