### PR TITLE
Add time stamp to evaluation

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,17 +1,7 @@
 import pytest
 from click.testing import CliRunner
 
-from statue.cache import Cache
-
 
 @pytest.fixture
 def cli_runner():
     return CliRunner()
-
-
-# Cache Mocks
-
-
-@pytest.fixture
-def mock_cache_extract_time_stamp_from_path(mocker):
-    return mocker.patch.object(Cache, "extract_time_stamp_from_path")

--- a/tests/cli/history/test_history_list.py
+++ b/tests/cli/history/test_history_list.py
@@ -10,178 +10,187 @@ from tests.util import evaluation_mock
 def case_empty_history():
     additional_flags = []
     evaluations = []
-    evaluation_datetimes = []
     output = "No previous evaluations.\n"
-    return additional_flags, evaluations, evaluation_datetimes, output
+    return additional_flags, evaluations, output
 
 
 def case_one_successful_evaluation():
     total_commands = 4
+    timestamp1 = datetime.datetime(
+        year=2020, month=4, day=15, hour=12, minute=7, second=42
+    )
 
     additional_flags = []
     evaluations = [
         evaluation_mock(
+            timestamp=timestamp1,
             successful_commands=total_commands,
             total_commands=total_commands,
             total_execution_duration=0.234,
         )
     ]
-    evaluation_datetimes = [
-        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42)
-    ]
     output = "1) 04/15/2020, 12:07:42 - Success (4/4 successful, 0.23 seconds)\n"
-    return additional_flags, evaluations, evaluation_datetimes, output
+    return additional_flags, evaluations, output
 
 
 def case_one_failed_evaluation():
     additional_flags = []
+    timestamp1 = datetime.datetime(
+        year=2020, month=5, day=12, hour=14, minute=8, second=23
+    )
     evaluations = [
         evaluation_mock(
+            timestamp=timestamp1,
             successful_commands=3,
             total_commands=4,
             total_execution_duration=0.591,
         )
     ]
-    evaluation_datetimes = [
-        datetime.datetime(year=2020, month=5, day=12, hour=14, minute=8, second=23)
-    ]
     output = "1) 05/12/2020, 14:08:23 - Failure (3/4 successful, 0.59 seconds)\n"
-    return additional_flags, evaluations, evaluation_datetimes, output
+    return additional_flags, evaluations, output
 
 
 def case_two_successful_evaluations():
     total_commands1, total_commands2 = 4, 7
 
     additional_flags = []
+    timestamp1, timestamp2 = (
+        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42),
+        datetime.datetime(year=2020, month=4, day=14, hour=18, minute=59, second=11),
+    )
     evaluations = [
         evaluation_mock(
+            timestamp=timestamp1,
             successful_commands=total_commands1,
             total_commands=total_commands1,
             total_execution_duration=0.234,
         ),
         evaluation_mock(
+            timestamp=timestamp2,
             successful_commands=total_commands2,
             total_commands=total_commands2,
             total_execution_duration=0.189,
         ),
     ]
-    evaluation_datetimes = [
-        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42),
-        datetime.datetime(year=2020, month=4, day=14, hour=18, minute=59, second=11),
-    ]
     output = (
         "1) 04/15/2020, 12:07:42 - Success (4/4 successful, 0.23 seconds)\n"
         "2) 04/14/2020, 18:59:11 - Success (7/7 successful, 0.19 seconds)\n"
     )
-    return additional_flags, evaluations, evaluation_datetimes, output
+    return additional_flags, evaluations, output
 
 
 def case_one_failed_and_one_successful():
     total_commands = 4
 
     additional_flags = []
+    timestamp1, timestamp2 = (
+        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42),
+        datetime.datetime(year=2020, month=4, day=14, hour=18, minute=59, second=11),
+    )
     evaluations = [
         evaluation_mock(
+            timestamp=timestamp1,
             successful_commands=total_commands,
             total_commands=total_commands,
             total_execution_duration=0.234,
         ),
         evaluation_mock(
+            timestamp=timestamp2,
             successful_commands=3,
             total_commands=7,
             total_execution_duration=0.189,
         ),
     ]
-    evaluation_datetimes = [
-        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42),
-        datetime.datetime(year=2020, month=4, day=14, hour=18, minute=59, second=11),
-    ]
     output = (
         "1) 04/15/2020, 12:07:42 - Success (4/4 successful, 0.23 seconds)\n"
         "2) 04/14/2020, 18:59:11 - Failure (3/7 successful, 0.19 seconds)\n"
     )
-    return additional_flags, evaluations, evaluation_datetimes, output
+    return additional_flags, evaluations, output
 
 
 def case_three_evaluations():
     total_commands1, total_commands2 = 4, 10
 
     additional_flags = []
+    timestamp1, timestamp2, timestamp3 = (
+        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42),
+        datetime.datetime(year=2020, month=4, day=14, hour=18, minute=59, second=11),
+        datetime.datetime(year=2020, month=4, day=14, hour=11, minute=31, second=22),
+    )
     evaluations = [
         evaluation_mock(
+            timestamp=timestamp1,
             successful_commands=total_commands1,
             total_commands=total_commands1,
             total_execution_duration=0.234,
         ),
         evaluation_mock(
+            timestamp=timestamp2,
             successful_commands=3,
             total_commands=7,
             total_execution_duration=0.189,
         ),
         evaluation_mock(
+            timestamp=timestamp3,
             successful_commands=total_commands2,
             total_commands=total_commands2,
             total_execution_duration=0.03,
         ),
-    ]
-    evaluation_datetimes = [
-        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42),
-        datetime.datetime(year=2020, month=4, day=14, hour=18, minute=59, second=11),
-        datetime.datetime(year=2020, month=4, day=14, hour=11, minute=31, second=22),
     ]
     output = (
         "1) 04/15/2020, 12:07:42 - Success (4/4 successful, 0.23 seconds)\n"
         "2) 04/14/2020, 18:59:11 - Failure (3/7 successful, 0.19 seconds)\n"
         "3) 04/14/2020, 11:31:22 - Success (10/10 successful, 0.03 seconds)\n"
     )
-    return additional_flags, evaluations, evaluation_datetimes, output
+    return additional_flags, evaluations, output
 
 
 def case_head_flag():
     total_commands1, total_commands2 = 4, 10
 
     additional_flags = ["--head=2"]
+    timestamp1, timestamp2, timestamp3 = (
+        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42),
+        datetime.datetime(year=2020, month=4, day=14, hour=18, minute=59, second=11),
+        datetime.datetime(year=2020, month=4, day=14, hour=11, minute=31, second=22),
+    )
     evaluations = [
         evaluation_mock(
+            timestamp=timestamp1,
             successful_commands=total_commands1,
             total_commands=total_commands1,
             total_execution_duration=0.234,
         ),
         evaluation_mock(
+            timestamp=timestamp2,
             successful_commands=3,
             total_commands=7,
             total_execution_duration=0.189,
         ),
         evaluation_mock(
+            timestamp=timestamp3,
             successful_commands=total_commands2,
             total_commands=total_commands2,
             total_execution_duration=0.03,
         ),
     ]
-    evaluation_datetimes = [
-        datetime.datetime(year=2020, month=4, day=15, hour=12, minute=7, second=42),
-        datetime.datetime(year=2020, month=4, day=14, hour=18, minute=59, second=11),
-        datetime.datetime(year=2020, month=4, day=14, hour=11, minute=31, second=22),
-    ]
     output = (
         "1) 04/15/2020, 12:07:42 - Success (4/4 successful, 0.23 seconds)\n"
         "2) 04/14/2020, 18:59:11 - Failure (3/7 successful, 0.19 seconds)\n"
     )
-    return additional_flags, evaluations, evaluation_datetimes, output
+    return additional_flags, evaluations, output
 
 
 @parametrize_with_cases(
-    argnames=["additional_flags", "evaluations", "evaluation_datetimes", "output"],
+    argnames=["additional_flags", "evaluations", "output"],
     cases=THIS_MODULE,
 )
 def test_history_list(
     additional_flags,
     evaluations,
-    evaluation_datetimes,
     output,
     cli_runner,
     mock_evaluation_load_from_file,
-    mock_cache_extract_time_stamp_from_path,
     mock_build_configuration_from_file,
 ):
     configuration = mock_build_configuration_from_file.return_value
@@ -189,9 +198,6 @@ def test_history_list(
         f"evaluation_{uuid.uuid4()}.json" for _ in range(len(evaluations))
     ]
     mock_evaluation_load_from_file.side_effect = evaluations
-    mock_cache_extract_time_stamp_from_path.side_effect = [
-        d.timestamp() for d in evaluation_datetimes
-    ]
 
     result = cli_runner.invoke(statue_cli, ["history", "list", *additional_flags])
 

--- a/tests/cli/history/test_history_show.py
+++ b/tests/cli/history/test_history_show.py
@@ -11,22 +11,26 @@ from tests.util import command_mock
 
 
 def case_empty_evaluation():
+    timestamp = datetime.datetime(
+        year=2020, month=4, day=15, hour=12, minute=7, second=42
+    )
     return dict(
         additional_flags=[],
         evaluation_number=0,
-        evaluation=Evaluation(),
-        datetime=datetime.datetime(
-            year=2020, month=4, day=15, hour=12, minute=7, second=42
-        ),
+        evaluation=Evaluation(timestamp=timestamp),
         output="04/15/2020, 12:07:42 - Success (0/0 successful, 0.00 seconds)\n",
     )
 
 
 def case_one_source_one_command():
+    timestamp = datetime.datetime(
+        year=2020, month=4, day=15, hour=12, minute=7, second=42
+    )
     return dict(
         additional_flags=[],
         evaluation_number=0,
         evaluation=Evaluation(
+            timestamp=timestamp,
             total_execution_duration=18.1,
             sources_evaluations={
                 SOURCE1: SourceEvaluation(
@@ -41,9 +45,6 @@ def case_one_source_one_command():
                 )
             },
         ),
-        datetime=datetime.datetime(
-            year=2020, month=4, day=15, hour=12, minute=7, second=42
-        ),
         output=(
             "04/15/2020, 12:07:42 - Success (1/1 successful, 18.10 seconds)\n"
             f"{SOURCE1} (1.20 seconds):\n"
@@ -53,10 +54,14 @@ def case_one_source_one_command():
 
 
 def case_one_source_two_commands_success():
+    timestamp = datetime.datetime(
+        year=2020, month=4, day=15, hour=12, minute=7, second=42
+    )
     return dict(
         additional_flags=[],
         evaluation_number=0,
         evaluation=Evaluation(
+            timestamp=timestamp,
             total_execution_duration=18.1,
             sources_evaluations={
                 SOURCE1: SourceEvaluation(
@@ -76,9 +81,6 @@ def case_one_source_two_commands_success():
                 )
             },
         ),
-        datetime=datetime.datetime(
-            year=2020, month=4, day=15, hour=12, minute=7, second=42
-        ),
         output=(
             "04/15/2020, 12:07:42 - Success (2/2 successful, 18.10 seconds)\n"
             f"{SOURCE1} (1.20 seconds):\n"
@@ -89,10 +91,14 @@ def case_one_source_two_commands_success():
 
 
 def case_one_source_two_commands_success_verbosely():
+    timestamp = datetime.datetime(
+        year=2020, month=4, day=15, hour=12, minute=7, second=42
+    )
     return dict(
         additional_flags=["--verbose"],
         evaluation_number=0,
         evaluation=Evaluation(
+            timestamp=timestamp,
             total_execution_duration=18.1,
             sources_evaluations={
                 SOURCE1: SourceEvaluation(
@@ -112,9 +118,6 @@ def case_one_source_two_commands_success_verbosely():
                 )
             },
         ),
-        datetime=datetime.datetime(
-            year=2020, month=4, day=15, hour=12, minute=7, second=42
-        ),
         output=(
             "04/15/2020, 12:07:42 - Success (2/2 successful, 18.10 seconds)\n"
             f"{SOURCE1} (1.20 seconds):\n"
@@ -127,10 +130,14 @@ def case_one_source_two_commands_success_verbosely():
 
 
 def case_one_source_two_commands_failure():
+    timestamp = datetime.datetime(
+        year=2020, month=4, day=15, hour=12, minute=7, second=42
+    )
     return dict(
         additional_flags=[],
         evaluation_number=0,
         evaluation=Evaluation(
+            timestamp=timestamp,
             total_execution_duration=18.1,
             sources_evaluations={
                 SOURCE1: SourceEvaluation(
@@ -150,9 +157,6 @@ def case_one_source_two_commands_failure():
                 )
             },
         ),
-        datetime=datetime.datetime(
-            year=2020, month=4, day=15, hour=12, minute=7, second=42
-        ),
         output=(
             "04/15/2020, 12:07:42 - Failure (1/2 successful, 18.10 seconds)\n"
             f"{SOURCE1} (1.20 seconds):\n"
@@ -163,10 +167,14 @@ def case_one_source_two_commands_failure():
 
 
 def case_two_sources_two_commands():
+    timestamp = datetime.datetime(
+        year=2020, month=4, day=15, hour=12, minute=7, second=42
+    )
     return dict(
         additional_flags=[],
         evaluation_number=0,
         evaluation=Evaluation(
+            timestamp=timestamp,
             total_execution_duration=18.1,
             sources_evaluations={
                 SOURCE1: SourceEvaluation(
@@ -191,9 +199,6 @@ def case_two_sources_two_commands():
                 ),
             },
         ),
-        datetime=datetime.datetime(
-            year=2020, month=4, day=15, hour=12, minute=7, second=42
-        ),
         output=(
             "04/15/2020, 12:07:42 - Failure (1/2 successful, 18.10 seconds)\n"
             f"{SOURCE1} (1.20 seconds):\n"
@@ -205,13 +210,13 @@ def case_two_sources_two_commands():
 
 
 def case_number_flag():
+    timestamp = datetime.datetime(
+        year=2020, month=4, day=15, hour=12, minute=7, second=42
+    )
     return dict(
         additional_flags=["-n", "5"],
         evaluation_number=4,
-        evaluation=Evaluation(),
-        datetime=datetime.datetime(
-            year=2020, month=4, day=15, hour=12, minute=7, second=42
-        ),
+        evaluation=Evaluation(timestamp=timestamp),
         output="04/15/2020, 12:07:42 - Success (0/0 successful, 0.00 seconds)\n",
     )
 
@@ -221,7 +226,6 @@ def test_history_show(
     case,
     tmp_path,
     cli_runner,
-    mock_cache_extract_time_stamp_from_path,
     mock_evaluation_load_from_file,
     mock_build_configuration_from_file,
 ):
@@ -229,7 +233,6 @@ def test_history_show(
     configuration = mock_build_configuration_from_file.return_value
     configuration.cache.evaluation_path.return_value = evaluation_path
     mock_evaluation_load_from_file.return_value = case["evaluation"]
-    mock_cache_extract_time_stamp_from_path.return_value = case["datetime"].timestamp()
 
     result = cli_runner.invoke(
         statue_cli, ["history", "show", *case["additional_flags"]]
@@ -242,14 +245,12 @@ def test_history_show(
         case["evaluation_number"]
     )
     mock_evaluation_load_from_file.assert_called_once_with(evaluation_path)
-    mock_cache_extract_time_stamp_from_path.assert_called_once_with(evaluation_path)
     assert result.output == case["output"]
 
 
 def test_history_show_fail_on_invalid_index(
     cli_runner, mock_build_configuration_from_file
 ):
-
     configuration = mock_build_configuration_from_file.return_value
     configuration.cache.evaluation_path.side_effect = IndexError
     result = cli_runner.invoke(statue_cli, ["history", "show", "-n", "-6"])

--- a/tests/cli/string_utils/test_evaluation_string.py
+++ b/tests/cli/string_utils/test_evaluation_string.py
@@ -27,7 +27,7 @@ def case_empty_evaluation():
 
 def case_one_source_one_command():
     evaluation = Evaluation(
-        {
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -56,7 +56,7 @@ def case_one_source_one_command():
 
 def case_one_source_two_commands():
     evaluation = Evaluation(
-        {
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -95,7 +95,7 @@ def case_one_source_two_commands():
 
 def case_two_sources_two_commands():
     evaluation = Evaluation(
-        {
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -140,7 +140,7 @@ def case_two_sources_two_commands():
 def case_evaluation_string_verbose():
     execution_duration = 0.25
     evaluation = Evaluation(
-        {
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -292,14 +292,14 @@ def case_two_sources_with_failures():
     argnames=["evaluation", "failure_evaluation", "commands_map"], cases=THIS_MODULE
 )
 def test_get_commands_map(evaluation, failure_evaluation, commands_map):
-    assert evaluation.failure_evaluation == failure_evaluation
+    assert commands_map == evaluation.commands_map
 
 
 @parametrize_with_cases(
     argnames=["evaluation", "failure_evaluation", "commands_map"], cases=THIS_MODULE
 )
 def test_get_failure_evaluation(evaluation, failure_evaluation, commands_map):
-    assert commands_map == evaluation.commands_map
+    assert evaluation.failure_evaluation == failure_evaluation
 
 
 @parametrize_with_cases(

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -28,7 +28,7 @@ def case_empty():
 @case(tags=[SUCCESSFUL_TAG])
 def case_all_successful():
     evaluation = Evaluation(
-        {
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -64,7 +64,7 @@ def case_all_successful():
             ),
         }
     )
-    failure_evaluation = Evaluation()
+    failure_evaluation = Evaluation(timestamp=evaluation.timestamp)
     commands_map = {
         SOURCE1: [COMMAND1, COMMAND2],
         SOURCE2: [COMMAND3, COMMAND4, COMMAND5],
@@ -76,7 +76,7 @@ def case_all_successful():
 def case_one_failure():
     failed_execution_duration = random.random()
     evaluation = Evaluation(
-        {
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -113,7 +113,8 @@ def case_one_failure():
         }
     )
     failure_evaluation = Evaluation(
-        {
+        timestamp=evaluation.timestamp,
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -123,7 +124,7 @@ def case_one_failure():
                     )
                 ]
             )
-        }
+        },
     )
     commands_map = {
         SOURCE1: [COMMAND1, COMMAND2],
@@ -139,7 +140,7 @@ def case_one_source_with_two_failures():
         random.random(),
     )
     evaluation = Evaluation(
-        {
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -181,7 +182,8 @@ def case_one_source_with_two_failures():
         }
     )
     failure_evaluation = Evaluation(
-        {
+        timestamp=evaluation.timestamp,
+        sources_evaluations={
             SOURCE2: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -196,7 +198,7 @@ def case_one_source_with_two_failures():
                     ),
                 ]
             )
-        }
+        },
     )
     commands_map = {
         SOURCE1: [COMMAND1, COMMAND2, COMMAND3],
@@ -213,7 +215,7 @@ def case_two_sources_with_failures():
         random.random(),
     )
     evaluation = Evaluation(
-        {
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -255,7 +257,8 @@ def case_two_sources_with_failures():
         }
     )
     failure_evaluation = Evaluation(
-        {
+        timestamp=evaluation.timestamp,
+        sources_evaluations={
             SOURCE1: SourceEvaluation(
                 [
                     CommandEvaluation(
@@ -279,7 +282,7 @@ def case_two_sources_with_failures():
                     )
                 ]
             ),
-        }
+        },
     )
     commands_map = {
         SOURCE1: [COMMAND1, COMMAND2, COMMAND3],

--- a/tests/evaluation/test_read_write_evaluation.py
+++ b/tests/evaluation/test_read_write_evaluation.py
@@ -1,3 +1,4 @@
+import datetime
 import random
 from pathlib import Path
 from unittest import mock
@@ -5,6 +6,7 @@ from unittest import mock
 from pytest_cases import THIS_MODULE, parametrize_with_cases
 
 from statue.command import Command
+from statue.constants import DATETIME_FORMAT
 from statue.evaluation import CommandEvaluation, Evaluation, SourceEvaluation
 from tests.constants import (
     ARG1,
@@ -19,13 +21,32 @@ from tests.constants import (
 
 
 def case_empty():
-    evaluation_json = dict(sources_evaluations={}, total_execution_duration=0)
+    evaluation_json = dict(
+        timestamp=datetime.datetime.now().strftime(DATETIME_FORMAT),
+        sources_evaluations={},
+        total_execution_duration=0,
+    )
     evaluation = Evaluation()
+    return evaluation_json, evaluation
+
+
+def case_with_predefined_datetime():
+    evaluation_json = dict(
+        timestamp="05/15/1984, 15:18:20",
+        sources_evaluations={},
+        total_execution_duration=0,
+    )
+    evaluation = Evaluation(
+        timestamp=datetime.datetime(
+            year=1984, month=5, day=15, hour=15, minute=18, second=20
+        )
+    )
     return evaluation_json, evaluation
 
 
 def case_one_source_no_commands():
     evaluation_json = dict(
+        timestamp=datetime.datetime.now().strftime(DATETIME_FORMAT),
         sources_evaluations={
             SOURCE1: dict(commands_evaluations=[], source_execution_duration=0)
         },
@@ -43,6 +64,7 @@ def case_one_source_one_commands():
         random.random(),
     )
     evaluation_json = dict(
+        timestamp=datetime.datetime.now().strftime(DATETIME_FORMAT),
         total_execution_duration=total_execution_duration,
         sources_evaluations={
             SOURCE1: dict(
@@ -81,6 +103,7 @@ def case_one_source_two_commands():
         total_execution_duration,
     ) = (random.random(), random.random(), random.random(), random.random())
     evaluation_json = dict(
+        timestamp=datetime.datetime.now().strftime(DATETIME_FORMAT),
         total_execution_duration=total_execution_duration,
         sources_evaluations={
             SOURCE1: dict(
@@ -138,6 +161,7 @@ def case_two_sources_two_commands():
         random.random(),
     )
     evaluation_json = dict(
+        timestamp=datetime.datetime.now().strftime(DATETIME_FORMAT),
         total_execution_duration=total_execution_duration,
         sources_evaluations={
             SOURCE1: dict(

--- a/tests/util.py
+++ b/tests/util.py
@@ -27,7 +27,7 @@ def build_commands_builders_map(*commands_builders: CommandBuilder):
 
 def build_failure_evaluation(commands_map):
     return Evaluation(
-        {
+        sources_evaluations={
             source: SourceEvaluation(
                 [
                     CommandEvaluation(

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,6 @@
+import datetime
 import random
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -83,12 +85,20 @@ def command_builder_mock(
     return command_builder
 
 
-def evaluation_mock(successful_commands, total_commands, total_execution_duration):
+def evaluation_mock(
+    successful_commands: int,
+    total_commands: int,
+    total_execution_duration: float,
+    timestamp: Optional[datetime.datetime] = None,
+):
     evaluation = mock.Mock()
     evaluation.successful_commands_number = successful_commands
     evaluation.commands_number = total_commands
     evaluation.success = successful_commands == total_commands
     evaluation.total_execution_duration = total_execution_duration
+    evaluation.timestamp = (
+        timestamp if timestamp is not None else datetime.datetime.now()
+    )
     return evaluation
 
 


### PR DESCRIPTION
**Description**
Save timestamp as part of the evaluation JSON.
This will allow us to avoid reading the evaluation path in order to get the evaluation time.

**Tests**
Fixed relevant tests.

**Alternatives**
Keep using the evaluation path. This is ill-advised since we don't always have the path of the evaluation. 

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
