### PR TITLE
Fix unstable unit tests with more than one dummy version

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -78,7 +78,8 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=raw-checker-failed,
+disable=unbalanced-tuple-unpacking,
+        raw-checker-failed,
         bad-inline-option,
         locally-disabled,
         file-ignored,

--- a/tests/cli/config/test_config_fix_versions.py
+++ b/tests/cli/config/test_config_fix_versions.py
@@ -1,6 +1,6 @@
 from statue.cli.cli import statue_cli
 from tests.constants import COMMAND1, COMMAND2
-from tests.util import command_builder_mock, dummy_version
+from tests.util import command_builder_mock, dummy_version, dummy_versions
 
 
 def test_config_fix_version_with_no_installed_packages(
@@ -50,7 +50,7 @@ def test_config_fix_version_with_two_installed_packages(
     mock_build_configuration_from_file,
     mock_configuration_path,
 ):
-    version1, version2 = dummy_version(), dummy_version()
+    version1, version2 = dummy_versions(2)
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1, installed=True, installed_version=version1),
         command_builder_mock(name=COMMAND2, installed=True, installed_version=version2),
@@ -89,7 +89,7 @@ def test_config_fix_version_latest(
     mock_build_configuration_from_file,
     mock_configuration_path,
 ):
-    version1, version2 = dummy_version(), dummy_version()
+    version1, version2 = dummy_versions(2)
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1, installed=True, installed_version=version1),
         command_builder_mock(name=COMMAND2, installed=True, installed_version=version2),

--- a/tests/command_builder/test_command_builder_is_installed.py
+++ b/tests/command_builder/test_command_builder_is_installed.py
@@ -1,6 +1,6 @@
 from statue.command_builder import CommandBuilder
 from tests.constants import COMMAND1, COMMAND_HELP_STRING1
-from tests.util import dummy_version
+from tests.util import dummy_version, dummy_versions
 
 
 def test_command_builder_not_installed(mock_get_package):
@@ -41,7 +41,7 @@ def test_command_builder_is_installed_correctly(mock_get_package):
 
 
 def test_command_builder_is_installed_incorrectly(mock_get_package):
-    version, installed_version = dummy_version(), dummy_version()
+    version, installed_version = dummy_versions(2)
     mock_get_package.return_value.version = installed_version
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
@@ -55,7 +55,7 @@ def test_command_builder_is_installed_incorrectly(mock_get_package):
 
 
 def test_command_builder_set_version_as_installed(mock_get_package):
-    version, installed_version = dummy_version(), dummy_version()
+    version, installed_version = dummy_versions(2)
     mock_get_package.return_value.version = installed_version
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version

--- a/tests/command_builder/test_command_builder_uninstall.py
+++ b/tests/command_builder/test_command_builder_uninstall.py
@@ -3,7 +3,7 @@ import sys
 from statue.command_builder import CommandBuilder
 from statue.verbosity import SILENT
 from tests.constants import COMMAND1, COMMAND_HELP_STRING1
-from tests.util import dummy_version
+from tests.util import dummy_version, dummy_versions
 
 
 def test_command_builder_uninstall(mock_get_package, mock_subprocess, environ):
@@ -50,7 +50,7 @@ def test_command_builder_uninstall_silently(mock_get_package, mock_subprocess, e
 def test_command_builder_uninstall_specified_version(
     mock_get_package, mock_subprocess, environ
 ):
-    version, installed_version = dummy_version(), dummy_version()
+    version, installed_version = dummy_versions(2)
     mock_get_package.return_value.version = installed_version
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version

--- a/tests/command_builder/test_command_builder_update_to_version.py
+++ b/tests/command_builder/test_command_builder_update_to_version.py
@@ -4,7 +4,7 @@ from unittest import mock
 from statue.command_builder import CommandBuilder
 from statue.verbosity import SILENT
 from tests.constants import COMMAND1, COMMAND_HELP_STRING1
-from tests.util import dummy_version
+from tests.util import dummy_version, dummy_versions
 
 
 def test_command_builder_update_to_version(mock_get_package, mock_subprocess, environ):
@@ -90,7 +90,7 @@ def test_command_builder_update_to_specific_version_when_installed_version_match
 def test_command_builder_update_to_specific_version_when_already_installed(
     mock_subprocess, environ
 ):
-    version, installed_version = dummy_version(), dummy_version()
+    version, installed_version = dummy_versions(2)
     command_builder = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
     )

--- a/tests/command_builder/test_command_builders_equality.py
+++ b/tests/command_builder/test_command_builders_equality.py
@@ -11,7 +11,7 @@ from tests.constants import (
     CONTEXT1,
     CONTEXT2,
 )
-from tests.util import dummy_version
+from tests.util import dummy_version, dummy_versions
 
 EQUAL_TAG = "equal"
 NOT_EQUAL_TAG = "not_equal"
@@ -106,7 +106,7 @@ def case_not_equal_different_help():
 
 @case(tags=[NOT_EQUAL_TAG])
 def case_not_equal_different_version():
-    version1, version2 = dummy_version(), dummy_version()
+    version1, version2 = dummy_versions(2)
     command_builder1 = CommandBuilder(
         name=COMMAND1, help=COMMAND_HELP_STRING1, version=version1
     )

--- a/tests/util.py
+++ b/tests/util.py
@@ -17,7 +17,7 @@ def dummy_time_stamps(
     now_timestmamp = datetime.datetime.now().replace(microsecond=0)
     time_stamps = [
         now_timestmamp + datetime.timedelta(seconds=delta)
-        for delta in random.sample(range(max_seconds_delta), k=n)
+        for delta in random.sample(list(range(max_seconds_delta)), k=n)
     ]
     time_stamps.sort(reverse=reverse)
     return time_stamps

--- a/tests/util.py
+++ b/tests/util.py
@@ -32,6 +32,16 @@ def dummy_version():
     return f"{major}.{minor}.{patch}"
 
 
+def dummy_versions(n: int):
+    versions = []
+    for _ in range(n):
+        version = dummy_version()
+        while version in versions:
+            version = dummy_version()
+        versions.append(version)
+    return versions
+
+
 def build_commands_builders_map(*commands_builders: CommandBuilder):
     return {
         commands_builders.name: commands_builders


### PR DESCRIPTION
**Description**
When generating two dummy versions in unit tests, sometimes the same version is generated twice.
This causes unit tests to fail.

Fixed that by introducing new method called `dummy_versions` that generates more than one version and checks that the versions are different.

**Tests**
All tests pass.

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
