### PR TITLE
Fix unstable cache test

### DIFF
--- a/tests/cache/test_cache_save_evaluation.py
+++ b/tests/cache/test_cache_save_evaluation.py
@@ -32,10 +32,10 @@ def test_save_evaluation(tmp_path, mock_evaluation_load_from_file):
     assert evaluation_path.exists()
 
 
-def test_save_evaluation_deletes_old_evaluations(
-    tmp_path, mock_evaluation_load_from_file
+@pytest.mark.parametrize("size", [random.randint(2, 100), 1])
+def test_save_evaluation_deletes_old_evaluations(  # pylint: disable=too-many-locals
+    tmp_path, mock_evaluation_load_from_file, size
 ):
-    size = random.randint(1, 100)
     cache_dir = tmp_path / "cache"
     evaluations_dir = cache_dir / "evaluations"
     evaluations_dir.mkdir(parents=True)
@@ -48,7 +48,7 @@ def test_save_evaluation_deletes_old_evaluations(
     ]
     for old_evaluation_file in old_evaluation_paths:
         old_evaluation_file.touch()
-    recent_evaluation_file = (
+    recent_evaluation_path = (
         evaluations_dir / f"evaluation-{int(recent_time_stamp.timestamp())}.json"
     )
 
@@ -57,16 +57,18 @@ def test_save_evaluation_deletes_old_evaluations(
         successful_evaluation_mock(timestamp=timestamp) for timestamp in old_time_stamps
     ]
     recent_evaluation.save_as_json.side_effect = lambda path: path.touch()
-    mock_evaluation_load_from_file.side_effect = [recent_evaluation] + old_evaluations
+    evaluation_paths_dict = dict(zip(old_evaluation_paths, old_evaluations))
+    evaluation_paths_dict[recent_evaluation_path] = recent_evaluation
+    mock_evaluation_load_from_file.side_effect = evaluation_paths_dict.get
 
     cache = Cache(size=size, cache_root_directory=cache_dir)
 
-    assert not recent_evaluation_file.exists()
+    assert not recent_evaluation_path.exists()
 
     cache.save_evaluation(recent_evaluation)
 
-    assert recent_evaluation_file.exists()
-    recent_evaluation.save_as_json.assert_called_with(recent_evaluation_file)
+    assert recent_evaluation_path.exists()
+    recent_evaluation.save_as_json.assert_called_with(recent_evaluation_path)
     for i, old_evaluation_file in enumerate(old_evaluation_paths[1:]):
         assert old_evaluation_file.exists(), f"The {i}th old file does not exist."
     assert not old_evaluation_paths[0].exists()


### PR DESCRIPTION
**Description**
Fixed `test_save_evaluation_deletes_old_evaluations` unstable test.
This test was failing when `size == 1`. Since `size` was generated randomly, it only failed from time to time.

**Tests**
The test now passes even when `size == 1`.

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
