### PR TITLE
Rafctor statue run

### DIFF
--- a/src/statue/cache.py
+++ b/src/statue/cache.py
@@ -96,10 +96,10 @@ class Cache:
         :type n: int
         :return: The nth evaluation
         :rtype: Evaluation
-        :raises IndexError: raised when receiving an invalid index for evaluation
+        :raises CacheError: raised when receiving an invalid index for evaluation
         """
         if n < 0 or n >= self.number_of_evaluations:
-            raise IndexError(
+            raise CacheError(
                 "Could not get the desired evaluation due to invalid index"
             )
         return self.all_evaluations[n]

--- a/src/statue/cache.py
+++ b/src/statue/cache.py
@@ -80,13 +80,20 @@ class Cache:
         self.all_evaluations.clear()
         evaluations = list(evaluations)
         evaluations.sort(key=lambda evaluation: evaluation.timestamp)
-        for evaluation in evaluations:
-            self._all_evaluations.appendleft(evaluation)
+        self._all_evaluations.extendleft(evaluations)
 
     @property
-    def number_of_evaluations(self):
+    def number_of_evaluations(self) -> int:
         """Get number of cached evaluations."""
         return len(self.all_evaluations)
+
+    @property
+    def recent_failed_evaluation(self) -> Evaluation:
+        """Get the most recent failed evaluation."""
+        for evaluation in self.all_evaluations:
+            if not evaluation.success:
+                return evaluation
+        raise CacheError("Could not find failed evaluation")
 
     def get_evaluation(self, n: int) -> Evaluation:
         """

--- a/src/statue/cli/history.py
+++ b/src/statue/cli/history.py
@@ -18,6 +18,7 @@ from statue.command import CommandEvaluation
 from statue.config.configuration import Configuration
 from statue.constants import DATETIME_FORMAT
 from statue.evaluation import Evaluation
+from statue.exceptions import CacheError
 from statue.verbosity import is_verbose
 
 
@@ -98,7 +99,7 @@ def show_evaluation_cli(
     """Show past evaluation."""
     try:
         evaluation = configuration.cache.get_evaluation(number - 1)
-    except IndexError:
+    except CacheError:
         click.echo(
             failure_style(f"Could not find evaluation with given index {number}")
         )

--- a/src/statue/cli/run.py
+++ b/src/statue/cli/run.py
@@ -19,7 +19,7 @@ from statue.cli.styled_strings import failure_style, name_style, source_style
 from statue.commands_filter import CommandsFilter
 from statue.config.configuration import Configuration
 from statue.evaluation import Evaluation
-from statue.exceptions import UnknownContext
+from statue.exceptions import CacheError, UnknownContext
 from statue.runner import RunnerMode, build_runner
 from statue.verbosity import is_silent, is_verbose
 
@@ -124,7 +124,7 @@ def run_cli(  # pylint: disable=too-many-arguments
             failed=failed,
             previous=previous,
         )
-    except IndexError:
+    except CacheError:
         pass
     except UnknownContext as error:
         click.echo(error)

--- a/src/statue/cli/string_util.py
+++ b/src/statue/cli/string_util.py
@@ -81,3 +81,38 @@ def evaluation_string(
                 )
             returned += f"{command_evaluation.captured_output_string}\n"
     return returned
+
+
+def evaluation_summary_string(evaluation: Evaluation) -> str:
+    """
+    Create a summary string of an evaluation.
+
+    :param evaluation: Evaluation to be printed
+    :type evaluation: Evaluation
+    :return: summary string
+    :rtype: str
+    """
+    if evaluation.commands_number == 0:
+        return "Empty evaluation."
+    if evaluation.success:
+        return (
+            "Statue finished successfully after "
+            f"{evaluation.total_execution_duration:.2f} seconds!"
+        )
+    summary_string = (
+        f"Statue has failed after {evaluation.total_execution_duration:.2f} "
+        "seconds on the following commands:\n"
+    )
+    for source, source_evaluation in evaluation.failure_evaluation.items():
+        summary_string += f"{source_style(source)}:\n"
+        summary_string += (
+            "\t"
+            + ", ".join(
+                [
+                    name_style(command_evaluation.command.name)
+                    for command_evaluation in source_evaluation
+                ]
+            )
+            + "\n"
+        )
+    return summary_string

--- a/src/statue/commands_map_builder.py
+++ b/src/statue/commands_map_builder.py
@@ -1,0 +1,91 @@
+"""Designated class for building commands map."""
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+from statue.commands_filter import CommandsFilter
+from statue.commands_map import CommandsMap
+from statue.config.configuration import Configuration
+from statue.context import Context
+from statue.evaluation import Evaluation
+from statue.exceptions import CacheError, CommandsMapBuilderError
+
+
+@dataclass
+class CommandsMapBuilder:  # pylint: disable=too-many-instance-attributes
+    """Commands map builder class."""
+
+    configuration: Configuration
+    specified_sources: Optional[List[Path]] = None
+    allowed_commands: Optional[List[str]] = None
+    denied_commands: Optional[List[str]] = None
+    contexts: List[Context] = field(default_factory=list)
+    previous: Optional[int] = None
+    failed: bool = False
+    failed_only: bool = False
+
+    @property
+    def default_filter(self):
+        """Get default filters for commands map."""
+        return CommandsFilter(
+            contexts=self.contexts,
+            allowed_commands=self.allowed_commands,
+            denied_commands=self.denied_commands,
+        )
+
+    @property
+    def build_from_cache(self) -> bool:
+        """Should build commands map using cached evaluations."""
+        return self.previous is not None or self.failed or self.failed_only
+
+    def build(self) -> CommandsMap:
+        """
+        Build commands map using the builders settings.
+
+        :return: Commands map from instruction
+        :rtype: CommandsMap
+        :raises CommandsMapBuilderError: Raised when no sources where specified
+        """
+        if self.failed and self.previous is not None:
+            raise CommandsMapBuilderError(
+                '"failed" and "previous" cannot both be set when building commands map'
+            )
+        if not self.build_from_cache:
+            sources = self.get_sources()
+            if len(sources) == 0:
+                raise CommandsMapBuilderError(
+                    "No source was specified and no Sources section in configuration."
+                )
+            return self.configuration.build_commands_map(
+                sources=sources, commands_filter=self.default_filter
+            )
+        evaluation = self.get_evaluation_from_cache()
+        if self.failed_only:
+            return evaluation.failure_evaluation.commands_map
+        return evaluation.commands_map
+
+    def get_evaluation_from_cache(self) -> Evaluation:
+        """
+        Get evaluation from cache based on flags.
+
+        :return: Desired evaluation object
+        :rtype: Evaluation
+        :raises CommandsMapBuilderError: Raised when cannot get evaluation from cache.
+        """
+        try:
+            if self.previous is not None:
+                return self.configuration.cache.get_evaluation(self.previous - 1)
+            return self.configuration.cache.recent_failed_evaluation
+        except CacheError as error:
+            raise CommandsMapBuilderError(str(error)) from error
+
+    def get_sources(self) -> List[Path]:
+        """
+        Get sources list for the commands map.
+
+        :return: Sources list for the commands map
+        :rtype: List[Path]
+        """
+        if self.specified_sources is None or len(self.specified_sources) == 0:
+            return self.configuration.sources_repository.sources_list
+        return list(self.specified_sources)

--- a/src/statue/exceptions.py
+++ b/src/statue/exceptions.py
@@ -50,6 +50,10 @@ class InvalidCommand(StatueException):
     """Command doesn't fit restrictions."""
 
 
+class CommandsMapBuilderError(StatueException):
+    """Could not build commands map."""
+
+
 class CommandExecutionError(StatueException):
     """Command cannot be executed."""
 

--- a/tests/cache/test_cache_basics.py
+++ b/tests/cache/test_cache_basics.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_cases import parametrize
 
 from statue.cache import Cache
+from statue.exceptions import CacheError
 from tests.util import dummy_time_stamps, successful_evaluation_mock
 
 
@@ -232,6 +233,6 @@ def test_cache_get_evaluation_with_invalid_index(
     cache = Cache(size=size, cache_root_directory=cache_dir)
 
     with pytest.raises(
-        IndexError, match="^Could not get the desired evaluation due to invalid index$"
+        CacheError, match="^Could not get the desired evaluation due to invalid index$"
     ):
         cache.get_evaluation(invalid_evaluation_index)

--- a/tests/cache/test_cache_basics.py
+++ b/tests/cache/test_cache_basics.py
@@ -6,7 +6,11 @@ from pytest_cases import parametrize
 
 from statue.cache import Cache
 from statue.exceptions import CacheError
-from tests.util import dummy_time_stamps, successful_evaluation_mock
+from tests.util import (
+    dummy_time_stamps,
+    failed_evaluation_mock,
+    successful_evaluation_mock,
+)
 
 
 def test_cache_constructor_with_none_root_directory(tmp_path):
@@ -124,6 +128,82 @@ def test_cache_get_evaluation(
     cache = Cache(size=size, cache_root_directory=cache_dir)
 
     assert cache.get_evaluation(evaluation_index) == evaluations[evaluation_index]
+
+
+def test_cache_recent_failed_evaluation_is_most_recent(
+    tmp_path, mock_evaluation_load_from_file
+):
+    timestamp1, timestamp2, timestamp3, timestamp4 = dummy_time_stamps(4, reverse=True)
+    cache_dir = tmp_path / "cache"
+    evaluations_dir = cache_dir / "evaluations"
+    evaluations_dir.mkdir(parents=True)
+    evaluation_paths = [evaluations_dir / f"evaluation_{i}.json" for i in range(4)]
+    for evaluation_file in evaluation_paths:
+        evaluation_file.touch()
+    evaluations = [
+        failed_evaluation_mock(timestamp=timestamp1),
+        successful_evaluation_mock(timestamp=timestamp2),
+        successful_evaluation_mock(timestamp=timestamp3),
+        failed_evaluation_mock(timestamp=timestamp4),
+    ]
+    mock_evaluation_load_from_file.side_effect = dict(
+        zip(evaluation_paths, evaluations)
+    ).get
+
+    size = random.randint(1, 100)
+    cache = Cache(size=size, cache_root_directory=cache_dir)
+
+    assert cache.recent_failed_evaluation == evaluations[0]
+
+
+def test_cache_recent_failed_evaluation_is_second_most_recent(
+    tmp_path, mock_evaluation_load_from_file
+):
+    timestamp1, timestamp2, timestamp3, timestamp4 = dummy_time_stamps(4, reverse=True)
+    cache_dir = tmp_path / "cache"
+    evaluations_dir = cache_dir / "evaluations"
+    evaluations_dir.mkdir(parents=True)
+    evaluation_paths = [evaluations_dir / f"evaluation_{i}.json" for i in range(4)]
+    for evaluation_file in evaluation_paths:
+        evaluation_file.touch()
+    evaluations = [
+        successful_evaluation_mock(timestamp=timestamp1),
+        failed_evaluation_mock(timestamp=timestamp2),
+        successful_evaluation_mock(timestamp=timestamp3),
+        failed_evaluation_mock(timestamp=timestamp4),
+    ]
+    mock_evaluation_load_from_file.side_effect = dict(
+        zip(evaluation_paths, evaluations)
+    ).get
+
+    size = random.randint(1, 100)
+    cache = Cache(size=size, cache_root_directory=cache_dir)
+
+    assert cache.recent_failed_evaluation == evaluations[1]
+
+
+def test_cache_recent_failed_evaluation_with_no_failed_evaluation(
+    tmp_path, mock_evaluation_load_from_file
+):
+    cache_dir = tmp_path / "cache"
+    evaluations_dir = cache_dir / "evaluations"
+    evaluations_dir.mkdir(parents=True)
+    evaluation_paths = [evaluations_dir / f"evaluation_{i}.json" for i in range(6)]
+    for evaluation_file in evaluation_paths:
+        evaluation_file.touch()
+    evaluations = [
+        successful_evaluation_mock(timestamp=time_stamp)
+        for time_stamp in dummy_time_stamps(len(evaluation_paths), reverse=True)
+    ]
+    mock_evaluation_load_from_file.side_effect = dict(
+        zip(evaluation_paths, evaluations)
+    ).get
+
+    size = random.randint(1, 100)
+    cache = Cache(size=size, cache_root_directory=cache_dir)
+
+    with pytest.raises(CacheError, match="^Could not find failed evaluation$"):
+        cache.recent_failed_evaluation  # pylint: disable=pointless-statement
 
 
 def test_cache_clear(tmp_path, mock_evaluation_load_from_file):

--- a/tests/cli/history/test_history_show.py
+++ b/tests/cli/history/test_history_show.py
@@ -5,6 +5,7 @@ from pytest_cases import THIS_MODULE, parametrize_with_cases
 from statue.cli import statue_cli
 from statue.command import CommandEvaluation
 from statue.evaluation import Evaluation, SourceEvaluation
+from statue.exceptions import CacheError
 from tests.constants import ARG1, ARG2, ARG3, ARG4, COMMAND1, COMMAND2, SOURCE1, SOURCE2
 from tests.util import command_mock
 
@@ -248,7 +249,7 @@ def test_history_show_fail_on_invalid_index(
     cli_runner, mock_build_configuration_from_file
 ):
     configuration = mock_build_configuration_from_file.return_value
-    configuration.cache.get_evaluation.side_effect = IndexError
+    configuration.cache.get_evaluation.side_effect = CacheError
     result = cli_runner.invoke(statue_cli, ["history", "show", "-n", "-6"])
 
     assert result.exit_code == 1

--- a/tests/cli/string_utils/test_evaluation_summary_string.py
+++ b/tests/cli/string_utils/test_evaluation_summary_string.py
@@ -1,0 +1,197 @@
+import random
+from pathlib import Path
+
+import click
+from pytest_cases import THIS_MODULE, parametrize_with_cases
+
+from statue.cli.string_util import evaluation_summary_string
+from statue.command import CommandEvaluation
+from statue.evaluation import Evaluation, SourceEvaluation
+from tests.constants import (
+    COMMAND1,
+    COMMAND2,
+    COMMAND3,
+    COMMAND4,
+    COMMAND5,
+    SOURCE1,
+    SOURCE2,
+    SOURCE3,
+    SOURCE4,
+)
+from tests.util import command_mock
+
+
+def case_empty_evaluation():
+    total_execution_duration = 13.32
+    evaluation = Evaluation(total_execution_duration=total_execution_duration)
+    expected_string = "Empty evaluation."
+
+    return evaluation, expected_string
+
+
+def case_success_one_source_one_command():
+    total_execution_duration = 14.15
+    evaluation = Evaluation(total_execution_duration=total_execution_duration)
+    evaluation[Path(SOURCE1)] = SourceEvaluation(
+        commands_evaluations=[
+            CommandEvaluation(
+                command=command_mock(COMMAND1),
+                success=True,
+                execution_duration=random.uniform(0, 100),
+            )
+        ],
+        source_execution_duration=random.uniform(0, 100),
+    )
+    expected_string = "Statue finished successfully after 14.15 seconds!"
+
+    return evaluation, expected_string
+
+
+def case_success_one_source_two_commands():
+    total_execution_duration = 9.31
+    evaluation = Evaluation(total_execution_duration=total_execution_duration)
+    evaluation[Path(SOURCE1)] = SourceEvaluation(
+        commands_evaluations=[
+            CommandEvaluation(
+                command=command_mock(COMMAND1),
+                success=True,
+                execution_duration=random.uniform(0, 100),
+            ),
+            CommandEvaluation(
+                command=command_mock(COMMAND2),
+                success=True,
+                execution_duration=random.uniform(0, 100),
+            ),
+        ],
+        source_execution_duration=random.uniform(0, 100),
+    )
+    expected_string = "Statue finished successfully after 9.31 seconds!"
+
+    return evaluation, expected_string
+
+
+def case_one_source_one_failed_command():
+    total_execution_duration = 9.31
+    evaluation = Evaluation(total_execution_duration=total_execution_duration)
+    evaluation[Path(SOURCE1)] = SourceEvaluation(
+        commands_evaluations=[
+            CommandEvaluation(
+                command=command_mock(COMMAND1),
+                success=False,
+                execution_duration=random.uniform(0, 100),
+            ),
+            CommandEvaluation(
+                command=command_mock(COMMAND2),
+                success=True,
+                execution_duration=random.uniform(0, 100),
+            ),
+        ],
+        source_execution_duration=random.uniform(0, 100),
+    )
+    expected_string = (
+        "Statue has failed after 9.31 seconds on the following commands:\n"
+        f"{SOURCE1}:\n"
+        f"\t{COMMAND1}\n"
+    )
+
+    return evaluation, expected_string
+
+
+def case_one_source_two_failed_commands():
+    total_execution_duration = 9.31
+    evaluation = Evaluation(total_execution_duration=total_execution_duration)
+    evaluation[Path(SOURCE1)] = SourceEvaluation(
+        commands_evaluations=[
+            CommandEvaluation(
+                command=command_mock(COMMAND1),
+                success=False,
+                execution_duration=random.uniform(0, 100),
+            ),
+            CommandEvaluation(
+                command=command_mock(COMMAND2),
+                success=False,
+                execution_duration=random.uniform(0, 100),
+            ),
+        ],
+        source_execution_duration=random.uniform(0, 100),
+    )
+    expected_string = (
+        "Statue has failed after 9.31 seconds on the following commands:\n"
+        f"{SOURCE1}:\n"
+        f"\t{COMMAND1}, {COMMAND2}\n"
+    )
+
+    return evaluation, expected_string
+
+
+def case_fail_multiple_sources():
+    total_execution_duration = 9.31
+    evaluation = Evaluation(total_execution_duration=total_execution_duration)
+    evaluation[Path(SOURCE1)] = SourceEvaluation(
+        commands_evaluations=[
+            CommandEvaluation(
+                command=command_mock(COMMAND1),
+                success=False,
+                execution_duration=random.uniform(0, 100),
+            ),
+            CommandEvaluation(
+                command=command_mock(COMMAND2),
+                success=False,
+                execution_duration=random.uniform(0, 100),
+            ),
+        ],
+        source_execution_duration=random.uniform(0, 100),
+    )
+    evaluation[Path(SOURCE2)] = SourceEvaluation(
+        commands_evaluations=[
+            CommandEvaluation(
+                command=command_mock(COMMAND3),
+                success=True,
+                execution_duration=random.uniform(0, 100),
+            )
+        ],
+        source_execution_duration=random.uniform(0, 100),
+    )
+    evaluation[Path(SOURCE3)] = SourceEvaluation(
+        commands_evaluations=[
+            CommandEvaluation(
+                command=command_mock(COMMAND4),
+                success=False,
+                execution_duration=random.uniform(0, 100),
+            )
+        ],
+        source_execution_duration=random.uniform(0, 100),
+    )
+    evaluation[Path(SOURCE4)] = SourceEvaluation(
+        commands_evaluations=[
+            CommandEvaluation(
+                command=command_mock(COMMAND1),
+                success=False,
+                execution_duration=random.uniform(0, 100),
+            ),
+            CommandEvaluation(
+                command=command_mock(COMMAND5),
+                success=False,
+                execution_duration=random.uniform(0, 100),
+            ),
+        ],
+        source_execution_duration=random.uniform(0, 100),
+    )
+    expected_string = (
+        "Statue has failed after 9.31 seconds on the following commands:\n"
+        f"{SOURCE1}:\n"
+        f"\t{COMMAND1}, {COMMAND2}\n"
+        f"{SOURCE3}:\n"
+        f"\t{COMMAND4}\n"
+        f"{SOURCE4}:\n"
+        f"\t{COMMAND1}, {COMMAND5}\n"
+    )
+
+    return evaluation, expected_string
+
+
+@parametrize_with_cases(argnames=["evaluation", "expected_string"], cases=THIS_MODULE)
+def test_evaluation_summary_string(evaluation, expected_string):
+    actual_result = evaluation_summary_string(evaluation)
+
+    assert click.unstyle(actual_result) == expected_string

--- a/tests/cli/test_run_cli.py
+++ b/tests/cli/test_run_cli.py
@@ -1,636 +1,808 @@
-import random
-from pathlib import Path
-
 import mock
 import pytest
-from pytest_cases import fixture, parametrize
 
-from statue.cli.cli import statue_cli
-from statue.commands_filter import CommandsFilter
-from statue.commands_map import CommandsMap
-from statue.exceptions import CacheError, UnknownContext
+from statue.cli import statue_cli
+from statue.exceptions import CommandsMapBuilderError, UnknownContext
 from statue.runner import RunnerMode
-from statue.verbosity import DEFAULT_VERBOSITY
-from tests.constants import (
-    COMMAND1,
-    COMMAND2,
-    COMMAND3,
-    COMMAND4,
-    NOT_EXISTING_CONTEXT,
-    SOURCE1,
-    SOURCE2,
-)
+from statue.verbosity import NORMAL, VERBOSE
+from tests.constants import COMMAND1, COMMAND2, COMMAND3, CONTEXT1, SOURCE1
 from tests.util import (
-    build_failure_evaluation,
     command_builder_mock,
-    command_mock,
+    failed_evaluation_mock,
     successful_evaluation_mock,
 )
 
-EVALUATION_STRING = "This is an evaluation"
+DEFAULT_EVALUATION_STRING = (
+    "##############\n"
+    "# Evaluation #\n"
+    "##############\n"
+    "This is a pretty evaluation string\n"
+    "\n"
+    "###########\n"
+    "# Summary #\n"
+    "###########\n"
+    "\n"
+    "This is a pretty evaluation summary string\n"
+)
 
 
-def build_commands_map():
-    return CommandsMap(
-        {
-            SOURCE1: [
-                command_mock(name=COMMAND1),
-                command_mock(name=COMMAND2),
-            ],
-            SOURCE2: [
-                command_mock(name=COMMAND1),
-                command_mock(name=COMMAND3),
-                command_mock(name=COMMAND4),
-            ],
-        }
+def run_flags(configuration, **kwargs):
+    default_flags = dict(
+        specified_sources=None,
+        configuration=configuration,
+        allowed_commands=None,
+        denied_commands=None,
+        contexts=[],
+        previous=None,
+        failed=False,
+        failed_only=False,
     )
+    default_flags.update(kwargs)
+    return default_flags
 
 
-@fixture
-def mock_evaluation_string(mocker):
-    evaluation_string_mock = mocker.patch("statue.cli.run.evaluation_string")
-    evaluation_string_mock.return_value = EVALUATION_STRING
-    return evaluation_string_mock
+@pytest.fixture
+def mock_commands_map_builder(mocker):
+    return mocker.patch("statue.cli.run.CommandsMapBuilder")
 
 
-@fixture
+@pytest.fixture
 def mock_build_runner(mocker):
     return mocker.patch("statue.cli.run.build_runner")
 
 
-def assert_evaluation_was_printed(result, evaluation_string_mock):
-    evaluation_string_mock.assert_called_once()
-    assert EVALUATION_STRING in result.output
+@pytest.fixture
+def mock_evaluation_string(mocker):
+    evaluation_string = mocker.patch("statue.cli.run.evaluation_string")
+    evaluation_string.return_value = "This is a pretty evaluation string"
+    return evaluation_string
 
 
-def assert_usage_was_shown(result):
-    assert result.output.startswith("Usage: statue run [OPTIONS] [SOURCES]...")
+@pytest.fixture
+def mock_evaluation_summary_string(mocker):
+    evaluation_summary_string = mocker.patch("statue.cli.run.evaluation_summary_string")
+    evaluation_summary_string.return_value = (
+        "This is a pretty evaluation summary string"
+    )
+    return evaluation_summary_string
 
 
-def test_simple_run(
+# Successful runs
+
+
+def test_run_cli_with_default_flags(
     cli_runner,
     mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
+    mock_commands_map_builder,
     mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
 ):
-    evaluation = successful_evaluation_mock()
-    commands_map = build_commands_map()
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = evaluation
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
     configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.return_value = commands_map
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
 
     result = cli_runner.invoke(statue_cli, ["run"])
 
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.build_commands_map.assert_called_once_with(
-        sources=[Path(SOURCE1), Path(SOURCE2)], commands_filter=CommandsFilter()
-    )
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
     configuration.cache.save_evaluation.assert_called_once_with(evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
 
 
-def test_run_with_no_cache(
+def test_run_cli_with_source(
+    tmp_path,
     cli_runner,
     mock_build_configuration_from_file,
-    mock_cwd,
+    mock_commands_map_builder,
+    mock_build_runner,
     mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    source = tmp_path / SOURCE1
+    source.touch()
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", str(source)])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(
+        **run_flags(configuration, specified_sources=[source])
+    )
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+@pytest.mark.parametrize("context_flag", ["-c", "--context"])
+def test_run_cli_with_context(
+    context_flag,
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    context = mock.Mock()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    configuration.contexts_repository = {CONTEXT1: context}
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", context_flag, CONTEXT1])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(
+        **run_flags(configuration, contexts=[context])
+    )
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+@pytest.mark.parametrize("allow_flag", ["-a", "--allow"])
+def test_run_cli_with_allowed_command(
+    allow_flag,
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", allow_flag, COMMAND2])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(
+        **run_flags(configuration, allowed_commands=[COMMAND2])
+    )
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+@pytest.mark.parametrize("deny_flag", ["-d", "--deny"])
+def test_run_cli_with_denied_command(
+    deny_flag,
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", deny_flag, COMMAND2])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(
+        **run_flags(configuration, denied_commands=[COMMAND2])
+    )
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+@pytest.mark.parametrize("previous_flag", ["-p", "--previous"])
+def test_run_cli_on_previous_evaluation(
+    previous_flag,
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    previous = 3
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", previous_flag, previous])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(
+        **run_flags(configuration, previous=previous)
+    )
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+@pytest.mark.parametrize("recent_flag", ["-r", "--recent"])
+def test_run_cli_on_recent_evaluation(
+    recent_flag,
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", recent_flag])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(
+        **run_flags(configuration, previous=1)
+    )
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+@pytest.mark.parametrize("failed_flag", ["-f", "--failed"])
+def test_run_cli_on_failed_evaluation(
+    failed_flag,
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", failed_flag])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(
+        **run_flags(configuration, failed=True)
+    )
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+@pytest.mark.parametrize("failed_only_flag", ["-fo", "--failed-only"])
+def test_run_cli_on_failed_only_evaluation(
+    failed_only_flag,
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", failed_only_flag])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(
+        **run_flags(configuration, failed_only=True)
+    )
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+def test_run_cli_with_empty_commands_map(
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
 ):
     configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.return_value = build_commands_map()
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 0
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+
+    result = cli_runner.invoke(statue_cli, ["run"])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == "No commands to run.\n"
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_not_called()
+    configuration.cache.save_evaluation.assert_not_called()
+    mock_evaluation_string.assert_not_called()
+
+
+def test_run_cli_verbosely(
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", "--verbose"])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == (
+        "Running evaluation in sync mode\n"
+        "##############\n"
+        "# Evaluation #\n"
+        "##############\n"
+        "This is a pretty evaluation string\n"
+        "\n"
+        "###########\n"
+        "# Summary #\n"
+        "###########\n"
+        "\n"
+        "This is a pretty evaluation summary string\n"
+    )
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=VERBOSE)
+
+
+def test_run_cli_silently(
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", "--silent"])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == "\nThis is a pretty evaluation summary string\n"
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_not_called()
+
+
+@pytest.mark.parametrize("install_flag", ["-i", "--install"])
+def test_run_cli_with_install_flag(
+    install_flag,
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    command_builder1, command_builder2, command_builder3 = (
+        command_builder_mock(COMMAND1, installed=False),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3, installed=False),
+    )
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = [
+        command_builder1,
+        command_builder2,
+        command_builder3,
+    ]
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run", install_flag])
+
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    command_builder1.update_to_version.assert_called_once_with(verbosity=NORMAL)
+    command_builder3.update_to_version.assert_called_once_with(verbosity=NORMAL)
+    command_builder2.update_to_version.assert_not_called()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+def test_run_cli_without_cache(
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
 
     result = cli_runner.invoke(statue_cli, ["run", "--no-cache"])
 
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.build_commands_map.assert_called_once()
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
     configuration.cache.save_evaluation.assert_not_called()
-    assert_evaluation_was_printed(result, mock_evaluation_string)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
 
 
-def test_run_and_install_uninstalled_commands(
+def test_run_cli_with_output_path(
+    tmp_path,
     cli_runner,
     mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
+    mock_commands_map_builder,
     mock_build_runner,
-):
-    evaluation = successful_evaluation_mock()
-    command_builder1, command_builder2, command_builder3 = (
-        command_builder_mock(COMMAND1, installed=True),
-        command_builder_mock(COMMAND2, installed=False),
-        command_builder_mock(COMMAND3, installed=True),
-    )
-    commands_map = CommandsMap(
-        {
-            SOURCE1: [
-                command_builder1.build_command.return_value,
-                command_builder2.build_command.return_value,
-            ],
-            SOURCE2: [command_builder3.build_command.return_value],
-        }
-    )
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = evaluation
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.commands_repository.add_command_builders(
-        command_builder1, command_builder2, command_builder3
-    )
-    configuration.build_commands_map.return_value = commands_map
-
-    result = cli_runner.invoke(statue_cli, ["run", "-i"])
-
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.build_commands_map.assert_called_once()
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-    command_builder1.update_to_version.assert_not_called()
-    command_builder2.update_to_version.assert_called_once_with(
-        verbosity=DEFAULT_VERBOSITY
-    )
-    command_builder3.update_to_version.assert_not_called()
-
-
-def test_run_and_save_to_file(
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
     mock_evaluation_string,
-    mock_build_runner,
+    mock_evaluation_summary_string,
 ):
-    commands_map = build_commands_map()
-    evaluation = successful_evaluation_mock()
+    output_path = tmp_path / "eval.json"
 
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = evaluation
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
     configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.return_value = commands_map
-    output_path = Path("path/to/output/dir")
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
 
     result = cli_runner.invoke(statue_cli, ["run", "-o", str(output_path)])
 
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.build_commands_map.assert_called_once()
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
     configuration.cache.save_evaluation.assert_called_once_with(evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
     evaluation.save_as_json.assert_called_once_with(output_path)
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
 
 
-def test_run_over_recent_commands(
+@pytest.mark.parametrize("runner_mode", RunnerMode)
+def test_run_cli_with_mode(
+    runner_mode,
     cli_runner,
     mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
+    mock_commands_map_builder,
     mock_build_runner,
-):
-    commands_map = build_commands_map()
-    old_evaluation = mock.Mock()
-    old_evaluation.commands_map = commands_map
-    new_evaluation = successful_evaluation_mock()
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = new_evaluation
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.cache.get_evaluation.return_value = old_evaluation
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-
-    result = cli_runner.invoke(statue_cli, ["run", "-r"])
-
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.cache.get_evaluation.assert_called_once_with(0)
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.cache.save_evaluation.assert_called_once_with(new_evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-
-def test_run_over_failed_commands(
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
     mock_evaluation_string,
-    mock_build_runner,
+    mock_evaluation_summary_string,
 ):
-    commands_map = build_commands_map()
-    old_evaluation = mock.Mock()
-    old_evaluation.failure_evaluation = build_failure_evaluation(commands_map)
-    new_evaluation = successful_evaluation_mock()
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = new_evaluation
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
     configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.cache.get_evaluation.return_value = old_evaluation
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = successful_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
 
-    result = cli_runner.invoke(statue_cli, ["run", "-f"])
+    result = cli_runner.invoke(statue_cli, ["run", "--mode", runner_mode.name])
 
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.cache.get_evaluation.assert_called_once_with(0)
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.cache.save_evaluation.assert_called_once_with(new_evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-
-def test_run_over_previous_commands(
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
-    mock_build_runner,
-):
-    n = 5
-    commands_map = build_commands_map()
-    old_evaluation = mock.Mock()
-    old_evaluation.commands_map = commands_map
-    new_evaluation = successful_evaluation_mock()
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = new_evaluation
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.cache.get_evaluation.return_value = old_evaluation
-
-    result = cli_runner.invoke(statue_cli, ["run", "-p", n])
-
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.cache.get_evaluation.assert_called_once_with(n - 1)
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.cache.save_evaluation.assert_called_once_with(new_evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-
-def test_run_over_previous_failed_commands(
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
-    mock_build_runner,
-):
-    n = 5
-    commands_map = build_commands_map()
-    old_evaluation = mock.Mock()
-    old_evaluation.failure_evaluation = build_failure_evaluation(commands_map)
-    new_evaluation = successful_evaluation_mock()
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = new_evaluation
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.cache.get_evaluation.return_value = old_evaluation
-
-    result = cli_runner.invoke(statue_cli, ["run", "-f", "-p", n])
-
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.cache.get_evaluation.assert_called_once_with(n - 1)
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.cache.save_evaluation.assert_called_once_with(new_evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-
-def test_run_over_recent_commands_with_empty_cache(
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
-):
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.cache.get_evaluation.side_effect = CacheError
-
-    result = cli_runner.invoke(statue_cli, ["run", "-r"])
-
-    assert result.exit_code == 0
-    assert_usage_was_shown(result)
-    configuration.cache.get_evaluation.assert_called_once_with(0)
-    mock_evaluation_string.assert_not_called()
-
-
-def test_run_has_failed(
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
-    mock_build_runner,
-):
-    commands_map = build_commands_map()
-    evaluation = mock.Mock()
-    evaluation.success = False
-    evaluation.total_execution_duration = random.uniform(1, 100)
-    evaluation.failure_evaluation = build_failure_evaluation(
-        {
-            SOURCE1: [command_mock(name=COMMAND2, success=False)],
-            SOURCE2: [command_mock(name=COMMAND3, success=False)],
-        }
-    )
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = evaluation
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.return_value = commands_map
-
-    result = cli_runner.invoke(statue_cli, ["run"])
-
-    assert result.exit_code == 1
-    configuration.build_commands_map.assert_called_once()
+    assert result.exit_code == 0, f"Failed with exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with(runner_mode.name)
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
     configuration.cache.save_evaluation.assert_called_once_with(evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-    for source, source_evaluation in evaluation.failure_evaluation.items():
-        failed_commands_string = ", ".join(
-            [
-                command_evaluation.command.name
-                for command_evaluation in source_evaluation
-            ]
-        )
-        failure_string = f"{source}:\n" f"\t{failed_commands_string}"
-        assert failure_string in result.output
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
 
 
-def test_run_with_unknown_context(
+# Failed runs
+
+
+def test_run_cli_fail_due_to_unknown_context(
     cli_runner,
     mock_build_configuration_from_file,
-    mock_cwd,
+    mock_commands_map_builder,
+    mock_build_runner,
     mock_evaluation_string,
+    mock_evaluation_summary_string,
 ):
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.side_effect = UnknownContext(
-        context_name=NOT_EXISTING_CONTEXT
-    )
+    mock_commands_map_builder.side_effect = UnknownContext(CONTEXT1)
 
-    result = cli_runner.invoke(statue_cli, ["run"])
+    result = cli_runner.invoke(statue_cli, ["run", "-c", CONTEXT1])
 
-    assert result.exit_code == 1
-    assert f'Could not find context named "{NOT_EXISTING_CONTEXT}"' in result.output
-    configuration.cache.save_evaluation.assert_not_called()
-    mock_evaluation_string.assert_not_called()
-
-
-def test_run_with_missing_configuration(
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
-):
-    result = cli_runner.invoke(statue_cli, ["run"])
-
-    assert result.exit_code == 1
     assert (
-        '"Run" command cannot be run without a specified source '
-        "or a sources section in Statue's configuration.\n"
-        'Please consider running "statue config init" in order to initialize '
-        "default configuration."
-    ) in result.output
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.cache.save_evaluation.assert_not_called()
+        result.exit_code == 1
+    ), f"Exit code is different than expected. Exception: {result.exception}"
+    assert result.output == 'Could not find context named "context1"\n'
+
+    mock_build_runner.assert_not_called()
     mock_evaluation_string.assert_not_called()
 
 
-def test_run_with_none_commands_map(
+def test_run_cli_fail_due_to_commands_map_builder_error(
     cli_runner,
     mock_build_configuration_from_file,
-    mock_cwd,
+    mock_commands_map_builder,
+    mock_build_runner,
     mock_evaluation_string,
+    mock_evaluation_summary_string,
 ):
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.return_value = None
+    message = "This is a message"
+    mock_commands_map_builder.side_effect = CommandsMapBuilderError(message)
 
     result = cli_runner.invoke(statue_cli, ["run"])
 
-    assert result.exit_code == 0
-    assert_usage_was_shown(result)
-    configuration.cache.save_evaluation.assert_not_called()
+    assert (
+        result.exit_code == 1
+    ), f"Exit code is different than expected. Exception: {result.exception}"
+    assert result.output == f"{message}\n"
+
+    mock_build_runner.assert_not_called()
     mock_evaluation_string.assert_not_called()
 
 
-def test_run_uninstalled_command(
+def test_run_cli_with_failed_evaluation(
     cli_runner,
     mock_build_configuration_from_file,
-    mock_cwd,
+    mock_commands_map_builder,
+    mock_build_runner,
     mock_evaluation_string,
+    mock_evaluation_summary_string,
+):
+    commands_builders = [
+        command_builder_mock(COMMAND1),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3),
+    ]
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.commands_repository = commands_builders
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
+    evaluation = failed_evaluation_mock()
+    mock_build_runner.return_value.evaluate.return_value = evaluation
+
+    result = cli_runner.invoke(statue_cli, ["run"])
+
+    assert (
+        result.exit_code == 1
+    ), f"Got unexpected exit error. exception: {result.exception}"
+    assert result.output == DEFAULT_EVALUATION_STRING
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    mock_build_runner.assert_called_once_with("SYNC")
+    mock_build_runner.return_value.evaluate.assert_called_once_with(commands_map)
+    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
+    evaluation.save_as_json.assert_not_called()
+    mock_evaluation_string.assert_called_once_with(evaluation, verbosity=NORMAL)
+
+
+def test_run_cli_fail_in_installed_commands(
+    cli_runner,
+    mock_build_configuration_from_file,
+    mock_commands_map_builder,
+    mock_build_runner,
+    mock_evaluation_string,
+    mock_evaluation_summary_string,
 ):
     command_builder1, command_builder2, command_builder3 = (
-        command_builder_mock(COMMAND1, installed=True),
-        command_builder_mock(COMMAND2, installed=False),
-        command_builder_mock(COMMAND3, installed=True),
+        command_builder_mock(COMMAND1, installed=False),
+        command_builder_mock(COMMAND2),
+        command_builder_mock(COMMAND3, installed=False),
     )
     configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.commands_repository.add_command_builders(
-        command_builder1, command_builder2, command_builder3
-    )
-    configuration.build_commands_map.return_value = CommandsMap(
-        {
-            SOURCE1: [
-                command_builder1.build_command.return_value,
-                command_builder2.build_command.return_value,
-            ],
-            SOURCE2: [command_builder3.build_command.return_value],
-        }
-    )
+    configuration.commands_repository = [
+        command_builder1,
+        command_builder2,
+        command_builder3,
+    ]
+    commands_map = mock.MagicMock()
+    commands_map.__len__.return_value = 3
+    commands_map.command_names = [COMMAND1, COMMAND2, COMMAND3]
+    mock_commands_map_builder.return_value.build.return_value = commands_map
 
     result = cli_runner.invoke(statue_cli, ["run"])
 
-    assert result.exit_code == 1
     assert (
-        "The following commands are not installed correctly: command2\n"
-        "Consider using the '-i' flag in order to install missing "
-        "commands before running"
-    ) in result.output
-    configuration.build_commands_map.assert_called_once()
+        result.exit_code == 1
+    ), f"Got unexpected exit error. exception: {result.exception}"
+    assert result.output == (
+        f"The following commands are not installed correctly: {COMMAND1}, {COMMAND3}\n"
+        "Consider using the '-i' flag in order to install missing commands before "
+        "running\n"
+    )
+    mock_commands_map_builder.assert_called_once_with(**run_flags(configuration))
+    mock_commands_map_builder.return_value.build.assert_called_once_with()
+    command_builder1.update_to_version.assert_not_called()
+    command_builder3.update_to_version.assert_not_called()
+    command_builder2.update_to_version.assert_not_called()
+    mock_build_runner.assert_not_called()
     configuration.cache.save_evaluation.assert_not_called()
-    mock_evaluation_string.assert_not_called()
-
-
-def test_run_on_given_source(
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
-    tmp_path,
-    mock_build_runner,
-):
-    commands_map = build_commands_map()
-    evaluation = successful_evaluation_mock()
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = evaluation
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.build_commands_map.return_value = commands_map
-    source = tmp_path / SOURCE1
-    source.touch()
-    result = cli_runner.invoke(statue_cli, ["run", str(source)])
-
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.build_commands_map.assert_called_once_with(
-        sources=[source], commands_filter=CommandsFilter()
-    )
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-
-@parametrize(argnames="runner_mode", argvalues=[RunnerMode.SYNC, RunnerMode.ASYNC])
-def test_run_with_mode(
-    cli_runner,
-    runner_mode,
-    mock_cwd,
-    mock_build_configuration_from_file,
-    mock_build_runner,
-    mock_evaluation_string,
-):
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.return_value = build_commands_map()
-    evaluation = mock_build_runner.return_value.evaluate.return_value
-    evaluation.success = True
-    evaluation.total_execution_duration = random.random()
-
-    result = cli_runner.invoke(
-        statue_cli, ["run", f"--mode={runner_mode.name.lower()}"]
-    )
-
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.build_commands_map.assert_called_once_with(
-        sources=[Path(SOURCE1), Path(SOURCE2)], commands_filter=CommandsFilter()
-    )
-    mock_build_runner.assert_called_once_with(runner_mode.name)
-    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-
-@pytest.mark.parametrize(
-    argnames="verbose_flag", argvalues=["--verbose", "--verbosity=verbose"]
-)
-def test_run_verbosely(
-    verbose_flag,
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
-    mock_build_runner,
-):
-    commands_map = build_commands_map()
-    evaluation = successful_evaluation_mock()
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = evaluation
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.return_value = commands_map
-
-    result = cli_runner.invoke(statue_cli, ["run", verbose_flag])
-
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    assert "Running evaluation in sync mode" in result.output
-    configuration.build_commands_map.assert_called_once_with(
-        sources=[Path(SOURCE1), Path(SOURCE2)], commands_filter=CommandsFilter()
-    )
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
-    assert_evaluation_was_printed(result, mock_evaluation_string)
-
-
-@pytest.mark.parametrize(
-    argnames="silent_flag", argvalues=["--silent", "--verbosity=silent"]
-)
-def test_run_silently(
-    silent_flag,
-    cli_runner,
-    mock_build_configuration_from_file,
-    mock_cwd,
-    mock_evaluation_string,
-    mock_build_runner,
-):
-    commands_map = build_commands_map()
-    evaluation = successful_evaluation_mock()
-
-    runner = mock_build_runner.return_value
-    runner.evaluate.return_value = evaluation
-    configuration = mock_build_configuration_from_file.return_value
-    configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
-    configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.build_commands_map.return_value = commands_map
-
-    result = cli_runner.invoke(statue_cli, ["run", silent_flag])
-
-    assert (
-        result.exit_code == 0
-    ), f"Command failed with the following exception: {result.exception}"
-    assert "Statue finished successfully" in result.output
-    configuration.build_commands_map.assert_called_once_with(
-        sources=[Path(SOURCE1), Path(SOURCE2)], commands_filter=CommandsFilter()
-    )
-    mock_build_runner.assert_called_once_with(RunnerMode.SYNC.name)
-    runner.evaluate.assert_called_once_with(commands_map)
-    configuration.cache.save_evaluation.assert_called_once_with(evaluation)
     mock_evaluation_string.assert_not_called()

--- a/tests/cli/test_run_cli.py
+++ b/tests/cli/test_run_cli.py
@@ -8,7 +8,7 @@ from pytest_cases import fixture, parametrize
 from statue.cli.cli import statue_cli
 from statue.commands_filter import CommandsFilter
 from statue.commands_map import CommandsMap
-from statue.exceptions import UnknownContext
+from statue.exceptions import CacheError, UnknownContext
 from statue.runner import RunnerMode
 from statue.verbosity import DEFAULT_VERBOSITY
 from tests.constants import (
@@ -345,7 +345,7 @@ def test_run_over_recent_commands_with_empty_cache(
     configuration = mock_build_configuration_from_file.return_value
     configuration.sources_repository[Path(SOURCE1)] = mock.Mock()
     configuration.sources_repository[Path(SOURCE2)] = mock.Mock()
-    configuration.cache.get_evaluation.side_effect = IndexError
+    configuration.cache.get_evaluation.side_effect = CacheError
 
     result = cli_runner.invoke(statue_cli, ["run", "-r"])
 

--- a/tests/test_commands_map_builder.py
+++ b/tests/test_commands_map_builder.py
@@ -1,0 +1,237 @@
+import random
+
+import mock
+import pytest
+
+from statue.cache import Cache
+from statue.commands_filter import CommandsFilter
+from statue.commands_map_builder import CommandsMapBuilder
+from statue.config.configuration import Configuration
+from statue.context import Context
+from statue.exceptions import CacheError, CommandsMapBuilderError
+from tests.constants import (
+    COMMAND1,
+    COMMAND2,
+    COMMAND3,
+    CONTEXT1,
+    CONTEXT2,
+    CONTEXT3,
+    CONTEXT_HELP_STRING1,
+    CONTEXT_HELP_STRING2,
+    CONTEXT_HELP_STRING3,
+    SOURCE1,
+    SOURCE2,
+    SOURCE3,
+)
+
+# Successful tests
+
+
+def test_commands_map_builder_with_default_settings(tmp_path):
+    sources_list = [tmp_path / SOURCE1, tmp_path / SOURCE2, tmp_path / SOURCE3]
+    configuration = mock.Mock()
+    configuration.sources_repository.sources_list = sources_list
+    commands_map_builder = CommandsMapBuilder(configuration=configuration)
+
+    commands_map = commands_map_builder.build()
+
+    assert commands_map == configuration.build_commands_map.return_value
+    configuration.build_commands_map.assert_called_once_with(
+        sources=sources_list, commands_filter=CommandsFilter()
+    )
+
+
+def test_commands_map_builder_with_specified_sources(tmp_path):
+    sources_list = [tmp_path / SOURCE1, tmp_path / SOURCE2, tmp_path / SOURCE3]
+    configuration = mock.Mock()
+    commands_map_builder = CommandsMapBuilder(
+        specified_sources=sources_list, configuration=configuration
+    )
+
+    commands_map = commands_map_builder.build()
+
+    assert commands_map == configuration.build_commands_map.return_value
+    configuration.build_commands_map.assert_called_once_with(
+        sources=sources_list, commands_filter=CommandsFilter()
+    )
+
+
+def test_commands_map_builder_with_allowed_commands(tmp_path):
+    sources_list = [tmp_path / SOURCE1, tmp_path / SOURCE2, tmp_path / SOURCE3]
+    allowed_commands = [COMMAND1, COMMAND2, COMMAND3]
+    configuration = mock.Mock()
+    configuration.sources_repository.sources_list = sources_list
+    commands_map_builder = CommandsMapBuilder(
+        specified_sources=sources_list,
+        configuration=configuration,
+        allowed_commands=allowed_commands,
+    )
+
+    commands_map = commands_map_builder.build()
+
+    assert commands_map == configuration.build_commands_map.return_value
+    configuration.build_commands_map.assert_called_once_with(
+        sources=sources_list,
+        commands_filter=CommandsFilter(allowed_commands=allowed_commands),
+    )
+
+
+def test_commands_map_builder_with_denied_commands(tmp_path):
+    sources_list = [tmp_path / SOURCE1, tmp_path / SOURCE2, tmp_path / SOURCE3]
+    denied_commands = [COMMAND1, COMMAND2, COMMAND3]
+    configuration = mock.Mock()
+    configuration.sources_repository.sources_list = sources_list
+    commands_map_builder = CommandsMapBuilder(
+        specified_sources=sources_list,
+        configuration=configuration,
+        denied_commands=denied_commands,
+    )
+
+    commands_map = commands_map_builder.build()
+
+    assert commands_map == configuration.build_commands_map.return_value
+    configuration.build_commands_map.assert_called_once_with(
+        sources=sources_list,
+        commands_filter=CommandsFilter(denied_commands=denied_commands),
+    )
+
+
+def test_commands_map_builder_with_contexts(tmp_path):
+    sources_list = [tmp_path / SOURCE1, tmp_path / SOURCE2, tmp_path / SOURCE3]
+    contexts = [
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+        Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+    ]
+    configuration = mock.Mock()
+    configuration.sources_repository.sources_list = sources_list
+    commands_map_builder = CommandsMapBuilder(
+        specified_sources=sources_list, configuration=configuration, contexts=contexts
+    )
+
+    commands_map = commands_map_builder.build()
+
+    assert commands_map == configuration.build_commands_map.return_value
+    configuration.build_commands_map.assert_called_once_with(
+        sources=sources_list, commands_filter=CommandsFilter(contexts=contexts)
+    )
+
+
+def test_commands_map_builder_on_previous_evaluation():
+    previous = 3
+    configuration = mock.Mock()
+    commands_map_builder = CommandsMapBuilder(
+        configuration=configuration, previous=previous
+    )
+
+    commands_map = commands_map_builder.build()
+
+    assert commands_map == configuration.cache.get_evaluation.return_value.commands_map
+    configuration.cache.get_evaluation.assert_called_once_with(previous - 1)
+
+
+def test_commands_map_builder_on_failed_evaluation():
+    configuration = mock.Mock()
+    commands_map_builder = CommandsMapBuilder(configuration=configuration, failed=True)
+
+    commands_map = commands_map_builder.build()
+
+    assert commands_map == configuration.cache.recent_failed_evaluation.commands_map
+
+
+def test_commands_map_builder_with_failed_only():
+    configuration = mock.Mock()
+    commands_map_builder = CommandsMapBuilder(
+        configuration=configuration, failed_only=True
+    )
+
+    commands_map = commands_map_builder.build()
+
+    assert (
+        commands_map
+        == configuration.cache.recent_failed_evaluation.failure_evaluation.commands_map
+    )
+
+
+def test_commands_map_builder_with_previous_and_failed_only():
+    previous = 3
+    configuration = mock.Mock()
+    commands_map_builder = CommandsMapBuilder(
+        configuration=configuration, failed_only=True, previous=previous
+    )
+
+    commands_map = commands_map_builder.build()
+    expected_commands_map = (
+        configuration.cache.get_evaluation.return_value.failure_evaluation.commands_map
+    )
+
+    assert commands_map == expected_commands_map
+    configuration.cache.get_evaluation.assert_called_once_with(previous - 1)
+
+
+# Exception tests
+
+
+def test_commands_map_builder_cannot_be_set_with_both_failed_and_previous():
+    commands_map_builder = CommandsMapBuilder(
+        configuration=mock.Mock(), previous=random.randint(0, 5), failed=True
+    )
+
+    with pytest.raises(
+        CommandsMapBuilderError,
+        match='^"failed" and "previous" cannot both be set when building commands map$',
+    ):
+        commands_map_builder.build()
+
+
+def test_commands_map_builder_fail_due_to_empty_sources(tmp_path):
+    configuration = mock.Mock()
+    configuration.sources_repository.sources_list = []
+    commands_map_builder = CommandsMapBuilder(configuration=configuration)
+
+    with pytest.raises(
+        CommandsMapBuilderError,
+        match="^No source was specified and no Sources section in configuration.$",
+    ):
+        commands_map_builder.build()
+
+
+def test_commands_map_builder_on_previous_evaluation_fails_due_to_cache_error():
+    previous = 3
+    error_message = "This is a message"
+    configuration = mock.Mock()
+    commands_map_builder = CommandsMapBuilder(
+        configuration=configuration, previous=previous
+    )
+    configuration.cache.get_evaluation.side_effect = CacheError(error_message)
+
+    with pytest.raises(CommandsMapBuilderError, match=f"^{error_message}$"):
+        commands_map_builder.build()
+
+    configuration.cache.get_evaluation.assert_called_once_with(previous - 1)
+
+
+def test_commands_map_builder_on_failed_evaluation_fails_due_to_cache_error():
+    message = "This is a message"
+    configuration = Configuration(cache=Cache(10))
+    commands_map_builder = CommandsMapBuilder(configuration=configuration, failed=True)
+    with mock.patch.object(
+        Cache, "recent_failed_evaluation", new_callable=mock.PropertyMock
+    ) as recent_failed_evaluation:
+        recent_failed_evaluation.side_effect = CacheError(message)
+        with pytest.raises(CommandsMapBuilderError, match=f"^{message}$"):
+            commands_map_builder.build()
+
+
+def test_commands_map_builder_on_failed_old_evaluation_fails_due_to_cache_error():
+    message = "This is a message"
+    configuration = Configuration(cache=Cache(10))
+    commands_map_builder = CommandsMapBuilder(
+        configuration=configuration, failed_only=True
+    )
+    with mock.patch.object(
+        Cache, "recent_failed_evaluation", new_callable=mock.PropertyMock
+    ) as recent_failed_evaluation:
+        recent_failed_evaluation.side_effect = CacheError(message)
+        with pytest.raises(CommandsMapBuilderError, match=f"^{message}$"):
+            commands_map_builder.build()

--- a/tests/util.py
+++ b/tests/util.py
@@ -141,6 +141,26 @@ def successful_evaluation_mock(
     )
 
 
+def failed_evaluation_mock(
+    total_commands: Optional[int] = None,
+    total_execution_duration: Optional[float] = None,
+    timestamp: Optional[datetime.datetime] = None,
+):
+    if total_commands is None:
+        total_commands = random.randint(1, 10)
+    if total_execution_duration is None:
+        total_execution_duration = random.uniform(0, 100)
+    successful_commands = random.randint(
+        0, total_commands - 1
+    )  # less than total commands
+    return evaluation_mock(
+        successful_commands=successful_commands,
+        total_commands=total_commands,
+        total_execution_duration=total_execution_duration,
+        timestamp=timestamp,
+    )
+
+
 def assert_calls(mock_obj, calls):
     assert mock_obj.call_count == len(
         calls


### PR DESCRIPTION
**Description**
Refactored `statue run`. This includes:

* `--failed` now searches for the most recent failed evaluation and run it.
* Adding new `--failed-only` flag to run only the failed commands and not the entire evaluation
* Moving the commands map building methods to their own class

**Tests**
Rewrote all `statue run` unit tests from scratch.

**Alternatives**
Keep `statue run` as it is.

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
