### PR TITLE
Update versions and use `pylint.extensions.docparams`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,15 +38,15 @@ include_package_data = True
 package_dir =
     = src
 install_requires =
-    importlib-resources>=5.6.0;python_version<'3.9'
+    importlib-resources>=5.7.1;python_version<'3.9'
     tomli >= 2.0.1
     tomli-w >= 1.0.0
-    click >= 8.1.0
+    click >= 8.1.3
     click-params >= 0.3.0
-    tqdm >= 4.63.1
+    tqdm >= 4.64.0
     GitPython >= 3.1.27
-    types-toml >= 0.10.4
-    types-setuptools >= 57.4.11
+    types-toml >= 0.10.6
+    types-setuptools >= 57.4.14
 
 [options.packages.find]
 where = src

--- a/src/statue/cli/config/config_show.py
+++ b/src/statue/cli/config/config_show.py
@@ -39,7 +39,7 @@ def show_config_tree_cli(config: Optional[Path]):
         source_commands_filter = configuration.sources_repository[source]
         context_names = [context.name for context in source_commands_filter.contexts]
         click.echo(
-            f"{source_style(source)} "
+            f"{source_style(str(source))} "
             f"({bullet_style('contexts')}: "
             f"{__join_names(context_names)}, "
             f"{bullet_style('allowed')}: "

--- a/src/statue/cli/config/interactive_adders/interactive_sources_adder.py
+++ b/src/statue/cli/config/interactive_adders/interactive_sources_adder.py
@@ -51,8 +51,8 @@ class InteractiveSourcesAdder:
                 choices.extend(EXPEND)
                 choices_string += f", {bullet_style('[E]xpend')}"
             option = click.prompt(
-                f"Would you like to track {source_style(source)} ({choices_string}. "
-                f"default: {success_style('yes')})",
+                f"Would you like to track {source_style(str(source))} "
+                f"({choices_string}. default: {success_style('yes')})",
                 type=click.Choice(choices, case_sensitive=False),
                 show_choices=False,
                 show_default=False,
@@ -120,7 +120,7 @@ class InteractiveSourcesAdder:
         while True:
             try:
                 context_names = click.prompt(
-                    f"Add {bullet_style('contexts')} to {source_style(source)} "
+                    f"Add {bullet_style('contexts')} to {source_style(str(source))} "
                     f"(options: [{contexts_options}])",
                     default="",
                     type=clickp.StringListParamType(),
@@ -170,7 +170,7 @@ class InteractiveSourcesAdder:
         )
         while True:
             command_names = click.prompt(
-                f"Add {style_func(prefix)} commands to {source_style(source)} "
+                f"Add {style_func(prefix)} commands to {source_style(str(source))} "
                 f"(options: [{commands_options}], "
                 f"No specified {prefix} commands by default)",
                 default="",

--- a/src/statue/cli/history.py
+++ b/src/statue/cli/history.py
@@ -107,7 +107,7 @@ def show_evaluation_cli(
     click.echo(total_evaluation_string(evaluation))
     for source, source_evaluation in evaluation.items():
         click.echo(
-            f"{source_style(source)} ("
+            f"{source_style(str(source))} ("
             f"{source_evaluation.source_execution_duration:.2f} seconds):"
         )
         for command_evaluation in source_evaluation.commands_evaluations:

--- a/src/statue/cli/string_util.py
+++ b/src/statue/cli/string_util.py
@@ -64,7 +64,7 @@ def evaluation_string(
     """
     returned = ""
     for source, source_evaluation in evaluation.items():
-        source_title = title_string(source_style(source), transform=False)
+        source_title = title_string(source_style(str(source)), transform=False)
         returned += f"\n\n{source_title}\n\n"
         for command_evaluation in source_evaluation:
             styled_command_name = name_style(command_evaluation.command.name)
@@ -104,7 +104,7 @@ def evaluation_summary_string(evaluation: Evaluation) -> str:
         "seconds on the following commands:\n"
     )
     for source, source_evaluation in evaluation.failure_evaluation.items():
-        summary_string += f"{source_style(source)}:\n"
+        summary_string += f"{source_style(str(source))}:\n"
         summary_string += (
             "\t"
             + ", ".join(

--- a/src/statue/cli/styled_strings.py
+++ b/src/statue/cli/styled_strings.py
@@ -2,55 +2,60 @@
 import click
 
 
-def source_style(source):
+def source_style(source: str) -> str:
     """
     Styling function to emphasise sources paths.
 
     :param source: The source name to style
+    :type source: str
     :return: Styles source
     :rtype: str
     """
     return click.style(source, fg="cyan")
 
 
-def name_style(name):
+def name_style(name: str) -> str:
     """
     Styling function to emphasise names.
 
     :param name: The name to style
+    :type name: str
     :return: Styled name
     :rtype: str
     """
     return click.style(name, fg="magenta")
 
 
-def bullet_style(bullet_name):
+def bullet_style(bullet_name: str) -> str:
     """
     Styling function to emphasise bullet names.
 
     :param bullet_name: The name to style
+    :type bullet_name: str
     :return: Styled bullet name
     :rtype: str
     """
     return click.style(bullet_name, fg="yellow")
 
 
-def success_style(success_string):
+def success_style(success_string: str) -> str:
     """
     Styling function to emphasise bullet names.
 
     :param success_string: The string to style
+    :type success_string: str
     :return: Styled success string
     :rtype: str
     """
     return click.style(success_string, fg="green")
 
 
-def failure_style(failure_string):
+def failure_style(failure_string: str) -> str:
     """
     Styling function to emphasise bullet names.
 
     :param failure_string: The string to style
+    :type failure_string: str
     :return: Styled failure string
     :rtype: str
     """

--- a/src/statue/command.py
+++ b/src/statue/command.py
@@ -114,12 +114,12 @@ class Command:
             ),
         )
 
-    async def execute_async(self, source) -> CommandEvaluation:
+    async def execute_async(self, source: Path) -> CommandEvaluation:
         """
         Execute the command asynchronously.
 
         :param source: source files to check.
-        :type: str
+        :type source: Path
         :return: Command's evaluation including the command itself and is it successful
         :rtype: CommandEvaluation
         :raises CommandExecutionError: raised when command is not found.

--- a/src/statue/templates/default_templates/defaults.toml
+++ b/src/statue/templates/default_templates/defaults.toml
@@ -122,6 +122,7 @@ allowed_contexts = [
 help = "Python code linter"
 args = [
     "--ignore-imports=y",
+    "--load-plugins=pylint.extensions.docparams",
     "--disable=bad-continuation",
     "--enable=useless-suppression,use-symbolic-message-instead",
     "--fail-on=useless-suppression,use-symbolic-message-instead",
@@ -130,8 +131,11 @@ args = [
 [commands.pylint.documentation]
 args = [
     "--ignore-imports=y",
+    "--load-plugins=pylint.extensions.docparams",
     "--disable=all",
-    "--enable=C0115,C0304,C0116,C0114"
+    "--enable=C0115,C0304,C0116,C0114",
+    "--enable=W9005,W9006,W9008,W9010,W9011,W9012,W9013",
+    "--enable=W9014,W9015,W9016,W9017,W9018,W9019,W9020,W9021",
 ]
 
 [commands.pylint.test]

--- a/statue.toml
+++ b/statue.toml
@@ -133,6 +133,7 @@ version = "6.1.1"
 help = "Python code linter"
 args = [
     "--ignore-imports=y",
+    "--load-plugins=pylint.extensions.docparams",
     "--disable=bad-continuation",
     "--enable=useless-suppression,use-symbolic-message-instead",
     "--fail-on=useless-suppression,use-symbolic-message-instead",
@@ -142,8 +143,11 @@ version = "2.13.7"
 [commands.pylint.documentation]
 args = [
     "--ignore-imports=y",
+    "--load-plugins=pylint.extensions.docparams",
     "--disable=all",
     "--enable=C0115,C0304,C0116,C0114",
+    "--enable=W9005,W9006,W9008,W9010,W9011,W9012,W9013",
+    "--enable=W9014,W9015,W9016,W9017,W9018,W9019,W9020,W9021",
 ]
 
 [commands.pylint.test]

--- a/statue.toml
+++ b/statue.toml
@@ -112,7 +112,7 @@ args = [
 allowed_contexts = [
     "test",
 ]
-version = "0.942"
+version = "0.950"
 
 [commands.mypy.strict]
 add_args = [
@@ -137,7 +137,7 @@ args = [
     "--enable=useless-suppression,use-symbolic-message-instead",
     "--fail-on=useless-suppression,use-symbolic-message-instead",
 ]
-version = "2.13.3"
+version = "2.13.7"
 
 [commands.pylint.documentation]
 args = [

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 7.1.1
+pytest >= 7.1.2
 pytest-mock >= 3.7.0
 pytest-cases >= 3.6.11
 pytest-asyncio >= 0.18.3


### PR DESCRIPTION
**Description**
Related to #155 

Updated all versions.
Also, added the usage of the `pylint.extensions.docparams`.
Right now, we see that there are errors that *Docparams* do not alert of and *Darglint* do.
Therefore, I did not remove the usage of *Darglint* in this PR.

**Tests**
Ran `statue run` with multiple contexts

**Alternatives**
Not relevant

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial: