### PR TITLE
Fix bug in command builder contexts

### DIFF
--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -91,13 +91,14 @@ class CommandBuilder:
         :param required_contexts: Required contexts to be set.
         :type required_contexts: Set[Context]
         """
+        required_contexts = set(required_contexts)
         if len(required_contexts) != 0:
             self._validate_consistency(
                 allowed_contexts=self.allowed_contexts,
                 required_contexts=required_contexts,
                 specified_contexts=self.specified_contexts,
             )
-        self._required_contexts = set(required_contexts)
+        self._required_contexts = required_contexts
 
     @property
     def allowed_contexts(self) -> Set[Context]:
@@ -112,13 +113,14 @@ class CommandBuilder:
         :param allowed_contexts: Allowed contexts to be set
         :type allowed_contexts: Set[Context]
         """
+        allowed_contexts = set(allowed_contexts)
         if len(allowed_contexts) != 0:
             self._validate_consistency(
                 allowed_contexts=allowed_contexts,
                 required_contexts=self.required_contexts,
                 specified_contexts=self.specified_contexts,
             )
-        self._allowed_contexts = set(allowed_contexts)
+        self._allowed_contexts = allowed_contexts
 
     @property
     def contexts_specifications(self) -> Dict[Context, ContextSpecification]:


### PR DESCRIPTION
**Description**
 `CommandBuilder` had a bug when trying to set allowed or required contexts as list.
This bug is now fixed and unit tests were added

**Tests**
Added relevant unit tests

**Alternatives**
Not relevant.

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
