### PR TITLE
Add command interactively

### DIFF
--- a/src/statue/cli/config/__init__.py
+++ b/src/statue/cli/config/__init__.py
@@ -1,6 +1,11 @@
 """Configuration related CLIs."""
 from statue.cli.config.config_cli import config_cli
-from statue.cli.config.config_commands import fixate_commands_versions_cli
+from statue.cli.config.config_commands import (
+    add_command_cli,
+    edit_command_cli,
+    fixate_commands_versions_cli,
+    remove_command_cli,
+)
 from statue.cli.config.config_contexts import (
     add_context_cli,
     edit_context_cli,
@@ -17,6 +22,9 @@ __all__ = [
     "add_context_cli",
     "edit_context_cli",
     "remove_context_cli",
+    "add_command_cli",
+    "edit_command_cli",
+    "remove_command_cli",
     "fixate_commands_versions_cli",
     "init_config_cli",
     "show_config_cli",

--- a/src/statue/cli/config/config_commands.py
+++ b/src/statue/cli/config/config_commands.py
@@ -1,4 +1,5 @@
 """Commands configuration CLI."""
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -6,7 +7,61 @@ import click
 
 from statue.cli.common_flags import config_path_option, verbose_option
 from statue.cli.config.config_cli import config_cli
+from statue.cli.config.interactive_adders.interactive_command_adder import (
+    InteractiveCommandAdder,
+)
+from statue.cli.styled_strings import failure_style, name_style
 from statue.config.configuration import Configuration
+from statue.exceptions import UnknownCommand
+
+
+@config_cli.command("add-command")
+@config_path_option
+def add_command_cli(config):
+    """Add new command to configuration."""
+    if config is None:
+        config = Configuration.configuration_path()
+    configuration = Configuration.from_file(config)
+    InteractiveCommandAdder.add_command(configuration)
+    configuration.to_toml(config)
+    click.echo("Command was successfully added!")
+
+
+@config_cli.command("edit-command")
+@config_path_option
+@click.argument("command_name", type=str)
+def edit_command_cli(config, command_name):
+    """Edit context from configuration."""
+    if config is None:
+        config = Configuration.configuration_path()
+    configuration = Configuration.from_file(config)
+    InteractiveCommandAdder.edit_command(name=command_name, configuration=configuration)
+    configuration.to_toml(config)
+    click.echo(f"{name_style(command_name)} was successfully edited!")
+
+
+@config_cli.command("remove-command")
+@config_path_option
+@click.argument("command_name", type=str)
+def remove_command_cli(config, command_name):
+    """Remove command from configuration."""
+    if config is None:
+        config = Configuration.configuration_path()
+    configuration = Configuration.from_file(config)
+    try:
+        command_builder = configuration.commands_repository[command_name]
+    except UnknownCommand as error:
+        click.echo(failure_style(str(error)))
+        sys.exit(1)
+    if not click.confirm(
+        f"Are you sure you would like to remove the command {name_style(command_name)} "
+        "and all of its references from configuration?",
+    ):
+        click.echo("Abort!")
+        return
+    configuration.remove_command(command_builder)
+    configuration.to_toml(config)
+    click.echo(f"{name_style(command_name)} was successfully removed!")
 
 
 @config_cli.command("fix-versions")

--- a/src/statue/cli/config/interactive_adders/adders_utils.py
+++ b/src/statue/cli/config/interactive_adders/adders_utils.py
@@ -1,0 +1,26 @@
+"""Utility module for interactive adders."""
+import click
+
+from statue.cli.styled_strings import failure_style, name_style
+
+
+def get_help_string(name: str) -> str:
+    """
+    Get help string for an object.
+
+    :param name: Name of the object to get help for
+    :type name: str
+    :return: help string for the object
+    :rtype: str
+    """
+    help_string = ""
+    while help_string == "":
+        help_string = click.prompt(
+            f"Please add help string for {name_style(name)}",
+            default="",
+            show_default=False,
+        )
+        help_string = help_string.strip()
+        if help_string == "":
+            click.echo(failure_style("Help string cannot be empty!"))
+    return help_string

--- a/src/statue/cli/config/interactive_adders/interactive_command_adder.py
+++ b/src/statue/cli/config/interactive_adders/interactive_command_adder.py
@@ -1,0 +1,231 @@
+"""Add commands to configuration interactively."""
+from typing import Dict, List, Optional, Set
+
+import click
+import click_params as clickp
+
+from statue.cli.config.interactive_adders.adders_utils import (
+    get_context,
+    get_contexts,
+    get_help_string,
+)
+from statue.cli.styled_strings import bullet_style, failure_style, name_style
+from statue.command_builder import CommandBuilder, ContextSpecification
+from statue.config.commands_repository import CommandsRepository
+from statue.config.configuration import Configuration
+from statue.config.contexts_repository import ContextsRepository
+from statue.context import Context
+from statue.exceptions import InconsistentConfiguration
+
+
+class InteractiveCommandAdder:
+    """Singleton class for adding and editing commands in configuration instance."""
+
+    @classmethod
+    def add_command(cls, configuration: Configuration):
+        """
+        Add commands interactively to commands repository.
+
+        :param configuration: Statue configuration
+        :type configuration: Configuration
+        """
+        name = cls.get_command_name(configuration.commands_repository)
+        help_string = get_help_string(name)
+        default_args = cls.get_args(name, args_type="default")
+        version = cls.get_version(name)
+        preoccupied_contexts = set()
+        required_contexts = get_contexts(
+            name=name,
+            contexts_repository=configuration.contexts_repository,
+            name_style_method=name_style,
+            contexts_type="required",
+        )
+        preoccupied_contexts.update(required_contexts)
+        allowed_contexts = get_contexts(
+            name=name,
+            contexts_repository=configuration.contexts_repository,
+            name_style_method=name_style,
+            contexts_type="allowed",
+            preoccupied_contexts=preoccupied_contexts,
+        )
+        preoccupied_contexts.update(allowed_contexts)
+        contexts_specifications = cls.get_contexts_specifications(
+            name=name,
+            contexts_repository=configuration.contexts_repository,
+            preoccupied_contexts=preoccupied_contexts,
+        )
+        configuration.commands_repository.add_command_builders(
+            CommandBuilder(
+                name=name,
+                help=help_string,
+                default_args=default_args,
+                version=version,
+                required_contexts=required_contexts,
+                allowed_contexts=allowed_contexts,
+                contexts_specifications=contexts_specifications,
+            )
+        )
+
+    @classmethod
+    def edit_command(cls, name: str, configuration: Configuration):
+        """
+        Edit a command interactively in commands repository.
+
+        :param name: Name of the command to edit
+        :type name: str
+        :param configuration: Statue configuration
+        :type configuration: Configuration
+        """
+        command_builder = configuration.commands_repository[name]
+        command_builder.help = get_help_string(name)
+        command_builder.default_args = cls.get_args(name, args_type="default")
+        command_builder.version = cls.get_version(name)
+        command_builder.reset_all_available_contexts()
+        command_builder.required_contexts = get_contexts(  # type: ignore
+            name=name,
+            contexts_repository=configuration.contexts_repository,
+            name_style_method=name_style,
+            contexts_type="required",
+        )
+        command_builder.allowed_contexts = get_contexts(  # type: ignore
+            name=name,
+            contexts_repository=configuration.contexts_repository,
+            name_style_method=name_style,
+            contexts_type="allowed",
+            preoccupied_contexts=command_builder.available_contexts,
+        )
+        command_builder.contexts_specifications = cls.get_contexts_specifications(
+            name=name,
+            contexts_repository=configuration.contexts_repository,
+            preoccupied_contexts=command_builder.available_contexts,
+        )
+
+    @classmethod
+    def get_command_name(cls, commands_repository: CommandsRepository) -> str:
+        """
+        Get context name interactively from user.
+
+        :param commands_repository: Commands repository to check
+            pre-existing commands in
+        :type commands_repository: CommandsRepository
+        :return: new command name
+        :rtype: str
+        """
+        name = ""
+        while name == "":
+            name = click.prompt(
+                f"Please choose {bullet_style('command')} name",
+                default="",
+                show_default=False,
+            )
+            name = name.strip()
+            if name in commands_repository:
+                click.echo(failure_style(f"{name} already exists in repository!"))
+                name = ""
+        return name
+
+    @classmethod
+    def get_args(cls, name: str, args_type: Optional[str] = None) -> List[str]:
+        """
+        Get default arguments for command from user.
+
+        :param name: Name of the command
+        :type name: str
+        :param args_type: Type of the arguments to get. Optional
+        :type args_type: Optional[str]
+        :return: List of default arguments
+        :rtype: List[str]
+        """
+        arguments_title = "arguments" if args_type is None else f"{args_type} arguments"
+        default_args = click.prompt(
+            f"Please add {arguments_title} of {name_style(name)} separated by spaces "
+            "(press enter to skip)",
+            default="",
+            type=clickp.StringListParamType(separator=" "),
+            show_default=False,
+        )
+        default_args = [arg for arg in default_args if arg.strip() != ""]
+        return default_args
+
+    @classmethod
+    def get_version(cls, name: str) -> Optional[str]:
+        """
+        Get version string for command from user.
+
+        Press enter to return empty version
+
+        :param name: Name of the command
+        :type name: str
+        :return: Optional version
+        :rtype: Optional[str]
+        """
+        version = click.prompt(
+            f"Please add {name_style(name)} version (press enter to skip)",
+            default="",
+            type=str,
+            show_default=False,
+        )
+        version = version.strip()
+        return None if version == "" else version
+
+    @classmethod
+    def get_contexts_specifications(
+        cls,
+        name: str,
+        contexts_repository: ContextsRepository,
+        preoccupied_contexts: Set[Context],
+    ) -> Dict[Context, ContextSpecification]:
+        """
+        Get contexts specifications dictionary from user.
+
+        :param name: Name of the command to get contexts specifications for
+        :type name: str
+        :param contexts_repository: Contexts repository to get contexts from
+        :type contexts_repository: ContextsRepository
+        :param preoccupied_contexts: Set of already taken contexts
+            that can't be specified
+        :type preoccupied_contexts: Set[Context]
+        :return: Dictionary from contexts to their specifications
+        :rtype: Dict[Context, ContextSpecification]
+        """
+        contexts_specification = {}
+        while True:
+            context = get_context(
+                contexts_repository=contexts_repository,
+                name=name,
+                name_style_method=name_style,
+                context_type="specified",
+                preoccupied_contexts=preoccupied_contexts,
+            )
+            if context is None:
+                break
+            contexts_specification[context] = cls.get_context_specification(
+                context.name
+            )
+            preoccupied_contexts.add(context)
+        return contexts_specification
+
+    @classmethod
+    def get_context_specification(cls, name: str) -> ContextSpecification:
+        """
+        Get context specification for a given context name.
+
+        :param name: Name of the context to be specified
+        :type name: str
+        :return: Context specification for the given context
+        :rtype: ContextSpecification
+        """
+        while True:
+            args = cls.get_args(name, args_type="override")
+            added_args = cls.get_args(name, args_type="added")
+            clear_args = click.confirm(
+                f"Would you like {name_style(name)} to clear arguments?", default=False
+            )
+            try:
+                return ContextSpecification(
+                    args=(args if len(args) != 0 else None),
+                    add_args=(added_args if len(added_args) != 0 else None),
+                    clear_args=clear_args,
+                )
+            except InconsistentConfiguration as error:
+                click.echo(failure_style(str(error)))

--- a/src/statue/cli/config/interactive_adders/interactive_context_adder.py
+++ b/src/statue/cli/config/interactive_adders/interactive_context_adder.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import click
 import click_params as clickp
 
+from statue.cli.config.interactive_adders.adders_utils import get_help_string
 from statue.cli.styled_strings import failure_style, name_style
 from statue.config.contexts_repository import ContextsRepository
 from statue.context import Context
@@ -17,11 +18,11 @@ class InteractiveContextAdder:
         """
         Add context interactively to context repository.
 
-        :param contexts_repository: contexts repository to add cotnext to
+        :param contexts_repository: contexts repository to add context to
         :type contexts_repository: ContextsRepository
         """
         name = cls.get_context_name(contexts_repository)
-        help_string = cls.get_help_string(name)
+        help_string = get_help_string(name)
         aliases = cls.get_aliases(name=name, contexts_repository=contexts_repository)
         parent = cls.get_parent(
             name=name, aliases=aliases, contexts_repository=contexts_repository
@@ -52,7 +53,7 @@ class InteractiveContextAdder:
         """
         context = contexts_repository[name]
         context.clear_aliases()
-        context.help = cls.get_help_string(name)
+        context.help = get_help_string(name)
         context.aliases = cls.get_aliases(
             name=name, contexts_repository=contexts_repository
         )
@@ -87,28 +88,6 @@ class InteractiveContextAdder:
                 click.echo(failure_style(f"{name} already exists in repository!"))
                 name = ""
         return name
-
-    @classmethod
-    def get_help_string(cls, context_name: str) -> str:
-        """
-        Get help string for context name.
-
-        :param context_name: Context name to get help for
-        :type context_name: str
-        :return: help string for the context
-        :rtype: str
-        """
-        help_string = ""
-        while help_string == "":
-            help_string = click.prompt(
-                f"Please add help string for {name_style(context_name)}",
-                default="",
-                show_default=False,
-            )
-            help_string = help_string.strip()
-            if help_string == "":
-                click.echo(failure_style("Help string cannot be empty!"))
-        return help_string
 
     @classmethod
     def get_aliases(

--- a/src/statue/command_builder.py
+++ b/src/statue/command_builder.py
@@ -236,6 +236,12 @@ class CommandBuilder:
             *self.specified_contexts,
         }
 
+    def reset_all_available_contexts(self):
+        """Reset all available contexts."""
+        self.required_contexts = []
+        self.allowed_contexts = []
+        self.contexts_specifications = {}
+
     def installed(self) -> bool:
         """
         Is this command installed.

--- a/src/statue/config/commands_repository.py
+++ b/src/statue/config/commands_repository.py
@@ -80,6 +80,15 @@ class CommandsRepository:
         for command_builder in command_builders:
             self.command_builders_map[command_builder.name] = command_builder
 
+    def remove_command_builder(self, command_builder: CommandBuilder):
+        """
+        Remove a command builder from repository.
+
+        :param command_builder: Command builder to be removed.
+        :type command_builder: CommandBuilder
+        """
+        del self.command_builders_map[command_builder.name]
+
     def reset(self):
         """Clear repository from all command builders."""
         self.command_builders_map.clear()

--- a/tests/cli/config/interactive_command_adder/test_add_command_interactively.py
+++ b/tests/cli/config/interactive_command_adder/test_add_command_interactively.py
@@ -1,0 +1,452 @@
+from statue.cli.config.interactive_adders.interactive_command_adder import (
+    InteractiveCommandAdder,
+)
+from statue.command_builder import CommandBuilder
+from statue.context import Context
+from statue.context_specification import ContextSpecification
+from tests.constants import (
+    ARG1,
+    ARG2,
+    ARG3,
+    ARG4,
+    COMMAND1,
+    COMMAND2,
+    COMMAND_HELP_STRING1,
+    COMMAND_HELP_STRING2,
+    CONTEXT1,
+    CONTEXT2,
+    CONTEXT3,
+    CONTEXT_HELP_STRING1,
+    CONTEXT_HELP_STRING2,
+    CONTEXT_HELP_STRING3,
+)
+from tests.util import dummy_version
+
+
+def test_interactive_add_command_with_simple_command(cli_runner, empty_configuration):
+
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(input=f"{COMMAND1}\n{COMMAND_HELP_STRING1}\n"):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1
+    )
+
+
+def test_interactive_add_command_re_ask_name(cli_runner, empty_configuration):
+
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(input=f"\n{COMMAND1}\n{COMMAND_HELP_STRING1}\n"):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1
+    )
+
+
+def test_interactive_add_command_with_preexisting_name(cli_runner, empty_configuration):
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND2, help=COMMAND_HELP_STRING2)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=f"{COMMAND2}\n{COMMAND1}\n{COMMAND_HELP_STRING1}\n"
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 2
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1
+    )
+    assert empty_configuration.commands_repository[COMMAND2] == CommandBuilder(
+        name=COMMAND2, help=COMMAND_HELP_STRING2
+    )
+
+
+def test_interactive_add_command_re_ask_help_string(cli_runner, empty_configuration):
+
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(input=f"{COMMAND1}\n\n{COMMAND_HELP_STRING1}\n"):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1
+    )
+
+
+def test_interactive_add_command_with_default_args(cli_runner, empty_configuration):
+
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            f"{ARG1} {ARG2}\n"  # default args
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, default_args=[ARG1, ARG2]
+    )
+
+
+def test_interactive_add_command_with_version(cli_runner, empty_configuration):
+    version = dummy_version()
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            f"{version}\n"  # version
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
+    )
+
+
+def test_interactive_add_command_with_required_contexts(
+    cli_runner, empty_configuration
+):
+    context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
+        name=CONTEXT2, help=CONTEXT_HELP_STRING2
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            f"{CONTEXT1}, {CONTEXT2}"  # required contexts
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[context1, context2]
+    )
+
+
+def test_interactive_add_command_re_ask_required_contexts_due_to_unknown_context(
+    cli_runner, empty_configuration
+):
+    context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
+        name=CONTEXT2, help=CONTEXT_HELP_STRING2
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            f"{CONTEXT3}, {CONTEXT2}\n"  # required contexts, context3 is unknown
+            f"{CONTEXT1}, {CONTEXT2}\n"  # required contexts
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[context1, context2]
+    )
+
+
+def test_interactive_add_command_with_allowed_contexts(cli_runner, empty_configuration):
+    context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
+        name=CONTEXT2, help=CONTEXT_HELP_STRING2
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            f"{CONTEXT1}, {CONTEXT2}"  # allowed contexts
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[context1, context2]
+    )
+
+
+def test_interactive_add_command_re_ask_allowed_contexts_due_to_unknown_context(
+    cli_runner, empty_configuration
+):
+    context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
+        name=CONTEXT2, help=CONTEXT_HELP_STRING2
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            f"{CONTEXT3}, {CONTEXT2}\n"  # allowed contexts, context3 is unknown
+            f"{CONTEXT1}, {CONTEXT2}\n"  # allowed contexts
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[context1, context2]
+    )
+
+
+def test_interactive_add_command_re_ask_allowed_contexts_due_to_taken_context(
+    cli_runner, empty_configuration
+):
+    context1, context2, context3 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+        Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2, context3)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            f"{CONTEXT3}\n"  # required context
+            f"{CONTEXT3}, {CONTEXT2}\n"  # allowed contexts, context3 is preoccupied
+            f"{CONTEXT1}, {CONTEXT2}\n"  # allowed contexts
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        required_contexts=[context3],
+        allowed_contexts=[context1, context2],
+    )
+
+
+def test_interactive_add_command_with_args_override_context(
+    cli_runner, empty_configuration
+):
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    empty_configuration.contexts_repository.add_contexts(context1)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT1}\n"  # Specified context
+            f"{ARG1} {ARG2}"  # override args
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(args=[ARG1, ARG2])},
+    )
+
+
+def test_interactive_add_command_with_added_args_context(
+    cli_runner, empty_configuration
+):
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    empty_configuration.contexts_repository.add_contexts(context1)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT1}\n"  # Specified context
+            "\n"  # no override args
+            f"{ARG1} {ARG2}"  # added args
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(add_args=[ARG1, ARG2])},
+    )
+
+
+def test_interactive_add_command_with_clear_args_context(
+    cli_runner, empty_configuration
+):
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    empty_configuration.contexts_repository.add_contexts(context1)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT1}\n"  # Specified context
+            "\n"  # no override args
+            "\n"  # no override args
+            "y\n"  # no override args
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(clear_args=True)},
+    )
+
+
+def test_interactive_add_command_with_both_added_args_and_override_context_fail(
+    cli_runner, empty_configuration
+):
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    empty_configuration.contexts_repository.add_contexts(context1)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT1}\n"  # Specified context
+            f"{ARG1} {ARG2}\n"  # override args
+            f"{ARG3} {ARG4}\n"  # also added args, which will cause error
+            "\n"  # no clear
+            f"{ARG1} {ARG2}\n"  # ask again for override args
+            "\n"  # no added args
+            "\n"  # no clear
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(args=[ARG1, ARG2])},
+    )
+
+
+def test_interactive_add_command_re_ask_specified_contexts_due_to_unknown_context(
+    cli_runner, empty_configuration
+):
+    context1, context2 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT3}\n"  # nknown context
+            f"{CONTEXT1}\n"  # specify context1 instead
+            f"{ARG1} {ARG2}"  # override args
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(args=[ARG1, ARG2])},
+    )
+
+
+def test_interactive_add_command_re_ask_specified_contexts_due_to_taken_context(
+    cli_runner, empty_configuration
+):
+    context1, context2, context3 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+        Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2, context3)
+    assert len(empty_configuration.commands_repository) == 0
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND1}\n"  # name
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            f"{CONTEXT3}\n"  # required context
+            "\n"  # no allowed contexts
+            f"{CONTEXT3}\n"  # try to specify context3 fail
+            f"{CONTEXT1}\n"  # specify context1 instead
+            f"{ARG1} {ARG2}"  # override args
+        )
+    ):
+        InteractiveCommandAdder.add_command(empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        required_contexts=[context3],
+        contexts_specifications={context1: ContextSpecification(args=[ARG1, ARG2])},
+    )

--- a/tests/cli/config/interactive_command_adder/test_edit_command_interactively.py
+++ b/tests/cli/config/interactive_command_adder/test_edit_command_interactively.py
@@ -1,0 +1,453 @@
+from statue.cli.config.interactive_adders.interactive_command_adder import (
+    InteractiveCommandAdder,
+)
+from statue.command_builder import CommandBuilder
+from statue.context import Context
+from statue.context_specification import ContextSpecification
+from tests.constants import (
+    ARG1,
+    ARG2,
+    ARG3,
+    ARG4,
+    COMMAND1,
+    COMMAND_HELP_STRING1,
+    CONTEXT1,
+    CONTEXT2,
+    CONTEXT3,
+    CONTEXT_HELP_STRING1,
+    CONTEXT_HELP_STRING2,
+    CONTEXT_HELP_STRING3,
+)
+from tests.util import dummy_version
+
+
+def test_interactive_edit_command_with_simple_command(cli_runner, empty_configuration):
+
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(input=f"{COMMAND_HELP_STRING1}\n"):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1
+    )
+
+
+def test_interactive_edit_command_re_ask_for_help_string(
+    cli_runner, empty_configuration
+):
+
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(input=f"\n{COMMAND_HELP_STRING1}\n"):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1
+    )
+
+
+def test_interactive_edit_command_with_default_args(cli_runner, empty_configuration):
+
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            f"{ARG1} {ARG2}\n"  # default args
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, default_args=[ARG1, ARG2]
+    )
+
+
+def test_interactive_edit_command_with_version(cli_runner, empty_configuration):
+    version = dummy_version()
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            f"{version}\n"  # version
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, version=version
+    )
+
+
+def test_interactive_edit_command_with_required_contexts(
+    cli_runner, empty_configuration
+):
+    context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
+        name=CONTEXT2, help=CONTEXT_HELP_STRING2
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            f"{CONTEXT1}, {CONTEXT2}"  # required contexts
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[context1, context2]
+    )
+
+
+def test_interactive_edit_command_re_ask_for_required_contexts_due_to_unknown_context(
+    cli_runner, empty_configuration
+):
+    context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
+        name=CONTEXT2, help=CONTEXT_HELP_STRING2
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            f"{CONTEXT3}, {CONTEXT2}\n"  # required contexts, context3 is unknown
+            f"{CONTEXT1}, {CONTEXT2}\n"  # required contexts
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, required_contexts=[context1, context2]
+    )
+
+
+def test_interactive_edit_command_with_allowed_contexts(
+    cli_runner, empty_configuration
+):
+    context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
+        name=CONTEXT2, help=CONTEXT_HELP_STRING2
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            f"{CONTEXT1}, {CONTEXT2}"  # allowed contexts
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[context1, context2]
+    )
+
+
+def test_interactive_edit_command_re_ask_for_allowed_contexts_due_to_unknown_context(
+    cli_runner, empty_configuration
+):
+    context1, context2 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1), Context(
+        name=CONTEXT2, help=CONTEXT_HELP_STRING2
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            f"{CONTEXT3}, {CONTEXT2}\n"  # allowed contexts, context3 is unknown
+            f"{CONTEXT1}, {CONTEXT2}\n"  # allowed contexts
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1, help=COMMAND_HELP_STRING1, allowed_contexts=[context1, context2]
+    )
+
+
+def test_interactive_edit_command_re_ask_for_allowed_contexts_due_to_taken_context(
+    cli_runner, empty_configuration
+):
+    context1, context2, context3 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+        Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2, context3)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            f"{CONTEXT3}\n"  # required context
+            f"{CONTEXT3}, {CONTEXT2}\n"  # allowed contexts, context3 is preoccupied
+            f"{CONTEXT1}, {CONTEXT2}\n"  # allowed contexts
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        required_contexts=[context3],
+        allowed_contexts=[context1, context2],
+    )
+
+
+def test_interactive_edit_command_with_args_override_context(
+    cli_runner, empty_configuration
+):
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    empty_configuration.contexts_repository.add_contexts(context1)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT1}\n"  # Specified context
+            f"{ARG1} {ARG2}"  # override args
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(args=[ARG1, ARG2])},
+    )
+
+
+def test_interactive_edit_command_with_added_args_context(
+    cli_runner, empty_configuration
+):
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    empty_configuration.contexts_repository.add_contexts(context1)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT1}\n"  # Specified context
+            "\n"  # no override args
+            f"{ARG1} {ARG2}"  # added args
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(add_args=[ARG1, ARG2])},
+    )
+
+
+def test_interactive_edit_command_with_clear_args_context(
+    cli_runner, empty_configuration
+):
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    empty_configuration.contexts_repository.add_contexts(context1)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT1}\n"  # Specified context
+            "\n"  # no override args
+            "\n"  # no override args
+            "y\n"  # no override args
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(clear_args=True)},
+    )
+
+
+def test_interactive_edit_command_with_both_added_args_and_override_context_fail(
+    cli_runner, empty_configuration
+):
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    empty_configuration.contexts_repository.add_contexts(context1)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT1}\n"  # Specified context
+            f"{ARG1} {ARG2}\n"  # override args
+            f"{ARG3} {ARG4}\n"  # also added args, which will cause error
+            "\n"  # no clear
+            f"{ARG1} {ARG2}\n"  # ask again for override args
+            "\n"  # no added args
+            "\n"  # no clear
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(args=[ARG1, ARG2])},
+    )
+
+
+def test_interactive_edit_command_re_ask_for_specified_context_due_to_unknown_context(
+    cli_runner, empty_configuration
+):
+    context1, context2 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            "\n"  # no required contexts
+            "\n"  # no allowed contexts
+            f"{CONTEXT3}\n"  # nknown context
+            f"{CONTEXT1}\n"  # specify context1 instead
+            f"{ARG1} {ARG2}"  # override args
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        contexts_specifications={context1: ContextSpecification(args=[ARG1, ARG2])},
+    )
+
+
+def test_interactive_edit_command_re_ask_for_specified_context_due_to_taken_context(
+    cli_runner, empty_configuration
+):
+    context1, context2, context3 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+        Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+    )
+    empty_configuration.contexts_repository.add_contexts(context1, context2, context3)
+    empty_configuration.commands_repository.add_command_builders(
+        CommandBuilder(name=COMMAND1, help=COMMAND_HELP_STRING1)
+    )
+    assert len(empty_configuration.commands_repository) == 1
+
+    with cli_runner.isolation(
+        input=(
+            f"{COMMAND_HELP_STRING1}\n"  # help string
+            "\n"  # no default args
+            "\n"  # no version
+            f"{CONTEXT3}\n"  # required context
+            "\n"  # no allowed contexts
+            f"{CONTEXT3}\n"  # fail because context3 is already taken
+            f"{CONTEXT1}\n"  # specify context1 instead
+            f"{ARG1} {ARG2}"  # override args
+        )
+    ):
+        InteractiveCommandAdder.edit_command(COMMAND1, empty_configuration)
+
+    assert len(empty_configuration.commands_repository) == 1
+    assert empty_configuration.commands_repository[COMMAND1] == CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        required_contexts=[context3],
+        contexts_specifications={context1: ContextSpecification(args=[ARG1, ARG2])},
+    )

--- a/tests/cli/config/test_config_command.py
+++ b/tests/cli/config/test_config_command.py
@@ -1,0 +1,155 @@
+import mock
+import pytest
+
+from statue.cli import statue_cli
+from statue.cli.config.interactive_adders.interactive_command_adder import (
+    InteractiveCommandAdder,
+)
+from statue.exceptions import UnknownCommand
+from tests.constants import COMMAND1
+
+
+def test_config_add_command_with_default_path(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path
+):
+    configuration = mock_build_configuration_from_file.return_value
+    with mock.patch.object(InteractiveCommandAdder, "add_command") as mock_add_command:
+        result = cli_runner.invoke(statue_cli, ["config", "add-command"])
+        mock_add_command.assert_called_once_with(configuration)
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 0
+
+
+def test_config_add_command_with_path(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path, tmp_path
+):
+    config_path = tmp_path / "statue.toml"
+    config_path.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    with mock.patch.object(InteractiveCommandAdder, "add_command") as mock_add_command:
+        result = cli_runner.invoke(
+            statue_cli, ["config", "add-command", "--config", str(config_path)]
+        )
+        mock_add_command.assert_called_once_with(configuration)
+
+    mock_build_configuration_from_file.assert_called_once_with(config_path)
+    mock_configuration_path.assert_not_called()
+    assert result.exit_code == 0
+
+
+def test_config_edit_command_with_default_path(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path
+):
+    configuration = mock_build_configuration_from_file.return_value
+    with mock.patch.object(
+        InteractiveCommandAdder, "edit_command"
+    ) as mock_edit_command:
+        result = cli_runner.invoke(statue_cli, ["config", "edit-command", COMMAND1])
+        mock_edit_command.assert_called_once_with(
+            name=COMMAND1, configuration=configuration
+        )
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 0
+
+
+def test_config_edit_command_with_path(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path, tmp_path
+):
+    config_path = tmp_path / "statue.toml"
+    config_path.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    with mock.patch.object(
+        InteractiveCommandAdder, "edit_command"
+    ) as mock_edit_command:
+        result = cli_runner.invoke(
+            statue_cli,
+            ["config", "edit-command", COMMAND1, "--config", str(config_path)],
+        )
+        mock_edit_command.assert_called_once_with(
+            name=COMMAND1, configuration=configuration
+        )
+
+    mock_build_configuration_from_file.assert_called_once_with(config_path)
+    mock_configuration_path.assert_not_called()
+    assert result.exit_code == 0
+
+
+def test_config_remove_command_with_default_path(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path
+):
+    mock_build_configuration_from_file.return_value = configuration = mock.MagicMock()
+    command = configuration.commands_repository.__getitem__.return_value
+    result = cli_runner.invoke(
+        statue_cli, ["config", "remove-command", COMMAND1], input="y\n"
+    )
+    configuration.commands_repository.__getitem__.assert_called_once_with(COMMAND1)
+    configuration.remove_command.assert_called_once_with(command)
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 0
+
+
+def test_config_remove_command_with_path(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path, tmp_path
+):
+    config_path = tmp_path / "statue.toml"
+    config_path.touch()
+    mock_build_configuration_from_file.return_value = configuration = mock.MagicMock()
+    command = configuration.commands_repository.__getitem__.return_value
+    result = cli_runner.invoke(
+        statue_cli,
+        ["config", "remove-command", COMMAND1, "--config", str(config_path)],
+        input="y\n",
+    )
+    configuration.commands_repository.__getitem__.assert_called_once_with(COMMAND1)
+    configuration.remove_command.assert_called_once_with(command)
+
+    mock_build_configuration_from_file.assert_called_once_with(config_path)
+    mock_configuration_path.assert_not_called()
+    assert result.exit_code == 0
+
+
+def test_config_remove_unknown_command_fails(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path, tmp_path
+):
+    config_path = tmp_path / "statue.toml"
+    config_path.touch()
+    mock_build_configuration_from_file.return_value = configuration = mock.MagicMock()
+    configuration.commands_repository.__getitem__.side_effect = UnknownCommand(COMMAND1)
+    result = cli_runner.invoke(
+        statue_cli,
+        ["config", "remove-command", COMMAND1, "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 1
+    assert result.output == f'Could not find command named "{COMMAND1}"\n'
+
+
+@pytest.mark.parametrize(argnames="abort_flag", argvalues=["", "n"])
+def test_config_remove_command_abort(
+    abort_flag, cli_runner, mock_build_configuration_from_file, mock_configuration_path
+):
+    mock_build_configuration_from_file.return_value = configuration = mock.MagicMock()
+    result = cli_runner.invoke(
+        statue_cli, ["config", "remove-command", COMMAND1], input=f"{abort_flag}\n"
+    )
+    configuration.commands_repository.__getitem__.assert_called_once_with(COMMAND1)
+    configuration.remove_command.assert_not_called()
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 0
+    assert result.output == (
+        "Are you sure you would like to remove the command command1 and all of its "
+        f"references from configuration? [y/N]: {abort_flag}\n"
+        "Abort!\n"
+    )

--- a/tests/command_builder/test_command_builder_basics.py
+++ b/tests/command_builder/test_command_builder_basics.py
@@ -331,6 +331,44 @@ def test_command_builder_set_contexts_specification():
     assert command_builder.contexts_specifications == contexts_specifications
 
 
+def test_command_builder_reset_all_available_contexts():
+    context1, context2, context3, context4, context5, context6 = (
+        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
+        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
+        Context(name=CONTEXT3, help=CONTEXT_HELP_STRING3),
+        Context(name=CONTEXT4, help=CONTEXT_HELP_STRING4),
+        Context(name=CONTEXT5, help=CONTEXT_HELP_STRING5),
+        Context(name=CONTEXT6, help=CONTEXT_HELP_STRING6),
+    )
+    context_specification1, context_specification2 = (
+        ContextSpecification(args=[ARG3]),
+        ContextSpecification(add_args=[ARG4]),
+    )
+    command_builder = CommandBuilder(
+        name=COMMAND1,
+        help=COMMAND_HELP_STRING1,
+        required_contexts=[context1, context2],
+        allowed_contexts=[context3, context4],
+        contexts_specifications={
+            context5: context_specification1,
+            context6: context_specification2,
+        },
+    )
+
+    assert command_builder.available_contexts == {
+        context1,
+        context2,
+        context3,
+        context4,
+        context5,
+        context6,
+    }
+
+    command_builder.reset_all_available_contexts()
+
+    assert not command_builder.available_contexts
+
+
 def test_command_builder_constructor_fail_on_one_context_both_allowed_and_required():
     context1, context2 = (
         Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),

--- a/tests/configuration/commands_repository/test_commands_repository_basics.py
+++ b/tests/configuration/commands_repository/test_commands_repository_basics.py
@@ -126,6 +126,41 @@ def test_commands_repository_add_command_overrides_existing():
     assert COMMAND2 not in commands_repository
 
 
+def test_iterate_commands_repository():
+    command_builder1, command_builder2, command_builder3 = (
+        command_builder_mock(name=COMMAND1),
+        command_builder_mock(name=COMMAND2),
+        command_builder_mock(name=COMMAND3),
+    )
+    commands_repository = CommandsRepository(
+        command_builder1, command_builder2, command_builder3
+    )
+
+    command_builders_list = list(commands_repository)
+    assert len(command_builders_list) == 3
+    assert command_builder1 in command_builders_list
+    assert command_builder2 in command_builders_list
+    assert command_builder3 in command_builders_list
+
+
+def test_commands_repository_remove_command():
+    command_builder1, command_builder2, command_builder3 = (
+        command_builder_mock(name=COMMAND1),
+        command_builder_mock(name=COMMAND2),
+        command_builder_mock(name=COMMAND3),
+    )
+    commands_repository = CommandsRepository(
+        command_builder1, command_builder2, command_builder3
+    )
+    commands_repository.remove_command_builder(command_builder2)
+
+    assert commands_repository[COMMAND1] == command_builder1
+    assert commands_repository[COMMAND3] == command_builder3
+    assert COMMAND1 in commands_repository
+    assert COMMAND2 not in commands_repository
+    assert COMMAND3 in commands_repository
+
+
 def test_commands_repository_reset():
     command_builder1, command_builder2 = (
         command_builder_mock(name=COMMAND1),

--- a/tests/configuration/configuration/test_configuration_remove.py
+++ b/tests/configuration/configuration/test_configuration_remove.py
@@ -3,6 +3,7 @@ import mock
 from statue.commands_filter import CommandsFilter
 from statue.config.configuration import Configuration
 from tests.constants import COMMAND1, COMMAND2, SOURCE1
+from tests.util import command_builder_mock
 
 
 def test_configuration_remove_context_from_contexts_configuration():
@@ -47,4 +48,54 @@ def test_configuration_remove_context_from_source(tmp_path):
 
     assert configuration.sources_repository[tmp_path / SOURCE1] == CommandsFilter(
         contexts=[context1, context3], allowed_commands=[COMMAND1, COMMAND2]
+    )
+
+
+def test_configuration_remove_command_builder_from_commands_configuration():
+    command_builder = mock.Mock()
+    configuration = Configuration(cache=mock.Mock())
+    configuration.commands_repository = mock.MagicMock()
+
+    configuration.remove_command(command_builder)
+
+    configuration.commands_repository.remove_command_builder.assert_called_once_with(
+        command_builder
+    )
+
+
+def test_configuration_remove_command_builder_from_allowed_commands_in_source(tmp_path):
+    context1, context2 = mock.Mock(), mock.Mock()
+    command_builder = command_builder_mock(name=COMMAND2)
+    configuration = Configuration(cache=mock.Mock())
+    configuration.commands_repository = mock.MagicMock()
+    configuration.sources_repository[tmp_path / SOURCE1] = CommandsFilter(
+        contexts=[context1, context2], allowed_commands=[COMMAND1, COMMAND2]
+    )
+
+    configuration.remove_command(command_builder)
+
+    assert configuration.sources_repository[tmp_path / SOURCE1] == CommandsFilter(
+        contexts=[context1, context2], allowed_commands=[COMMAND1]
+    )
+    configuration.commands_repository.remove_command_builder.assert_called_once_with(
+        command_builder
+    )
+
+
+def test_configuration_remove_command_builder_from_denied_commands_in_source(tmp_path):
+    context1, context2 = mock.Mock(), mock.Mock()
+    command_builder = command_builder_mock(name=COMMAND2)
+    configuration = Configuration(cache=mock.Mock())
+    configuration.commands_repository = mock.MagicMock()
+    configuration.sources_repository[tmp_path / SOURCE1] = CommandsFilter(
+        contexts=[context1, context2], denied_commands=[COMMAND1, COMMAND2]
+    )
+
+    configuration.remove_command(command_builder)
+
+    assert configuration.sources_repository[tmp_path / SOURCE1] == CommandsFilter(
+        contexts=[context1, context2], denied_commands=[COMMAND1]
+    )
+    configuration.commands_repository.remove_command_builder.assert_called_once_with(
+        command_builder
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from statue.config.commands_repository import CommandsRepository
 from statue.config.configuration import Configuration
 from statue.config.contexts_repository import ContextsRepository
 from statue.config.sources_repository import SourcesRepository
+from statue.constants import DEFAULT_HISTORY_SIZE
 from statue.evaluation import Evaluation
 from statue.templates.templates_provider import TemplatesProvider
 from tests.constants import ENVIRON
@@ -38,6 +39,13 @@ def mock_tqdm_range(mocker):
 
 
 # Configuration Mocks
+
+
+@pytest.fixture
+def empty_configuration(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache = Cache(size=DEFAULT_HISTORY_SIZE, cache_root_directory=cache_dir)
+    return Configuration(cache)
 
 
 @pytest.fixture


### PR DESCRIPTION
**Description**
One can now add, edit and remove commands via command line

**Tests**
Added relevant unit tests and ran `statue config` with the new commands

**Alternatives**
Not relevant

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
