### PR TITLE
Add sources via commandline

### DIFF
--- a/src/statue/cli/config/__init__.py
+++ b/src/statue/cli/config/__init__.py
@@ -14,6 +14,11 @@ from statue.cli.config.config_contexts import (
 from statue.cli.config.config_general import set_history_size_cli, set_mode_cli
 from statue.cli.config.config_init import init_config_cli
 from statue.cli.config.config_show import show_config_cli, show_config_tree_cli
+from statue.cli.config.config_sources import (
+    add_source_to_configuration_cli,
+    edit_source_in_configuration_cli,
+    remove_source_from_configuration_cli,
+)
 
 __all__ = [
     "config_cli",
@@ -26,6 +31,9 @@ __all__ = [
     "edit_command_cli",
     "remove_command_cli",
     "fixate_commands_versions_cli",
+    "add_source_to_configuration_cli",
+    "edit_source_in_configuration_cli",
+    "remove_source_from_configuration_cli",
     "init_config_cli",
     "show_config_cli",
     "show_config_tree_cli",

--- a/src/statue/cli/config/config_sources.py
+++ b/src/statue/cli/config/config_sources.py
@@ -1,0 +1,65 @@
+"""Sources configuration CLI."""
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import click
+
+from statue.cli.common_flags import config_path_option
+from statue.cli.config.config_cli import config_cli
+from statue.cli.config.interactive_adders.interactive_sources_adder import (
+    InteractiveSourcesAdder,
+)
+from statue.cli.styled_strings import failure_style, source_style
+from statue.config.configuration import Configuration
+
+
+@config_cli.command("add-source")
+@click.argument("sources", type=click.Path(exists=True, path_type=Path), nargs=-1)
+@config_path_option
+def add_source_to_configuration_cli(config: Optional[Path], sources: List[Path]):
+    """Add new source to configuration."""
+    if config is None:
+        config = Configuration.configuration_path()
+    configuration = Configuration.from_file(config)
+    InteractiveSourcesAdder.update_sources_repository(configuration, list(sources))
+    configuration.to_toml(config)
+    click.echo("Sources were added successfully!")
+
+
+@config_cli.command("edit-source")
+@click.argument("source", type=click.Path(exists=True, path_type=Path))
+@config_path_option
+def edit_source_in_configuration_cli(config: Optional[Path], source: Path):
+    """Edit a source from configuration."""
+    if config is None:
+        config = Configuration.configuration_path()
+    configuration = Configuration.from_file(config)
+    if source not in configuration.sources_repository.sources_list:
+        click.echo(failure_style(f"{source} is not specified in configuration"))
+        sys.exit(1)
+    configuration.sources_repository[source] = InteractiveSourcesAdder.get_filter(
+        configuration=configuration, source=source
+    )
+
+
+@config_cli.command("remove-source")
+@click.argument("source", type=click.Path(exists=True, path_type=Path))
+@config_path_option
+def remove_source_from_configuration_cli(config: Optional[Path], source: Path):
+    """Remove context from configuration."""
+    if config is None:
+        config = Configuration.configuration_path()
+    configuration = Configuration.from_file(config)
+    if source not in configuration.sources_repository.sources_list:
+        click.echo(failure_style(f"Could not find {source} in configuration."))
+        sys.exit(1)
+    if not click.confirm(
+        f"Are you sure you would like to remove the source {source_style(str(source))} "
+        "from configuration?",
+    ):
+        click.echo("Abort!")
+        return
+    configuration.sources_repository.remove_source(source)
+    configuration.to_toml(config)
+    click.echo(f"{source_style(str(source))} was successfully removed!")

--- a/src/statue/cli/config/interactive_adders/interactive_sources_adder.py
+++ b/src/statue/cli/config/interactive_adders/interactive_sources_adder.py
@@ -44,11 +44,15 @@ class InteractiveSourcesAdder:
         :type repo: Optional[Repo]
         """
         for source in sources:
-            choices = YES + NO
-            choices_string = f"{success_style('[Y]es')}, {failure_style('[N]o')}"
-            if source.is_dir():
-                choices.extend(EXPEND)
-                choices_string += f", {bullet_style('[E]xpend')}"
+            choices = cls._get_choices(configuration=configuration, source=source)
+            if choices == NO:
+                click.echo(
+                    failure_style(
+                        f"{source} was already defined in configuration. Skipping..."
+                    )
+                )
+                continue
+            choices_string = cls._get_choices_string(choices)
             option = click.prompt(
                 f"Would you like to track {source_style(str(source))} "
                 f"({choices_string}. default: {success_style('yes')})",
@@ -163,3 +167,20 @@ class InteractiveSourcesAdder:
                 )
                 continue
             return command_names
+
+    @classmethod
+    def _get_choices(cls, configuration: Configuration, source: Path):
+        choices = []
+        if source not in configuration.sources_repository.sources_list:
+            choices.extend(YES)
+        choices.extend(NO)
+        if source.is_dir():
+            choices.extend(EXPEND)
+        return choices
+
+    @classmethod
+    def _get_choices_string(cls, choices):
+        choices_string = f"{success_style('[Y]es')}, {failure_style('[N]o')}"
+        if EXPEND[0] in choices:
+            choices_string += f", {bullet_style('[E]xpend')}"
+        return choices_string

--- a/src/statue/config/sources_repository.py
+++ b/src/statue/config/sources_repository.py
@@ -74,6 +74,15 @@ class SourcesRepository:
         """Get list of all available sources."""
         return list(self.sources_filters_map.keys())
 
+    def remove_source(self, source: Path):
+        """
+        Remove source from repository.
+
+        :param source: Source to be removed
+        :type source Path
+        """
+        del self.sources_filters_map[source]
+
     def reset(self):
         """Reset sources repository."""
         self.sources_filters_map.clear()

--- a/tests/cli/config/test_config_sources.py
+++ b/tests/cli/config/test_config_sources.py
@@ -1,0 +1,192 @@
+import mock
+import pytest
+
+from statue.cli import statue_cli
+from statue.cli.config.interactive_adders.interactive_sources_adder import (
+    InteractiveSourcesAdder,
+)
+from statue.commands_filter import CommandsFilter
+from tests.constants import COMMAND3, SOURCE1
+
+
+def test_config_add_source_with_default_path(
+    cli_runner, tmp_path, mock_build_configuration_from_file, mock_configuration_path
+):
+    source = tmp_path / SOURCE1
+    source.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    with mock.patch.object(
+        InteractiveSourcesAdder, "update_sources_repository"
+    ) as mock_update_sources_repository:
+        result = cli_runner.invoke(statue_cli, ["config", "add-source", str(source)])
+        mock_update_sources_repository.assert_called_once_with(configuration, [source])
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 0
+
+
+def test_config_add_source_with_path(
+    cli_runner, tmp_path, mock_build_configuration_from_file, mock_configuration_path
+):
+    config_path, source = tmp_path / "statue.toml", tmp_path / SOURCE1
+    config_path.touch()
+    source.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    with mock.patch.object(
+        InteractiveSourcesAdder, "update_sources_repository"
+    ) as mock_update_sources_repository:
+        result = cli_runner.invoke(
+            statue_cli,
+            ["config", "add-source", str(source), "--config", str(config_path)],
+        )
+        mock_update_sources_repository.assert_called_once_with(configuration, [source])
+
+    mock_build_configuration_from_file.assert_called_once_with(config_path)
+    mock_configuration_path.assert_not_called()
+    assert result.exit_code == 0
+
+
+def test_config_edit_source_with_default_configuration_path(
+    cli_runner, tmp_path, mock_build_configuration_from_file, mock_configuration_path
+):
+    source = tmp_path / SOURCE1
+    source.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.sources_repository[source] = CommandsFilter(allowed_commands=COMMAND3)
+    with mock.patch.object(InteractiveSourcesAdder, "get_filter") as mock_get_filter:
+        result = cli_runner.invoke(statue_cli, ["config", "edit-source", str(source)])
+        mock_get_filter.assert_called_once_with(
+            configuration=configuration, source=source
+        )
+        assert configuration.sources_repository[source] == mock_get_filter.return_value
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 0
+
+
+def test_config_edit_source_with_configuration_path(
+    cli_runner, tmp_path, mock_build_configuration_from_file, mock_configuration_path
+):
+    config_path, source = tmp_path / "statue.toml", tmp_path / SOURCE1
+    config_path.touch()
+    source.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.sources_repository[source] = CommandsFilter(allowed_commands=COMMAND3)
+    with mock.patch.object(InteractiveSourcesAdder, "get_filter") as mock_get_filter:
+        result = cli_runner.invoke(
+            statue_cli,
+            ["config", "edit-source", str(source), "--config", str(config_path)],
+        )
+        mock_get_filter.assert_called_once_with(
+            configuration=configuration, source=source
+        )
+        assert configuration.sources_repository[source] == mock_get_filter.return_value
+
+    mock_build_configuration_from_file.assert_called_once_with(config_path)
+    mock_configuration_path.assert_not_called()
+    assert result.exit_code == 0
+
+
+def test_config_edit_non_existing_source(
+    cli_runner, tmp_path, mock_build_configuration_from_file, mock_configuration_path
+):
+    source = tmp_path / SOURCE1
+    source.touch()
+    with mock.patch.object(InteractiveSourcesAdder, "get_filter") as mock_get_filter:
+        result = cli_runner.invoke(
+            statue_cli,
+            ["config", "edit-source", str(source)],
+        )
+        mock_get_filter.assert_not_called()
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 1
+    assert result.output == f"{source} is not specified in configuration\n"
+
+
+def test_config_remove_source_with_default_configuration_path(
+    cli_runner, tmp_path, mock_build_configuration_from_file, mock_configuration_path
+):
+    source = tmp_path / SOURCE1
+    source.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.sources_repository[source] = CommandsFilter(allowed_commands=COMMAND3)
+    result = cli_runner.invoke(
+        statue_cli, ["config", "remove-source", str(source)], input="y\n"
+    )
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert source not in configuration.sources_repository.sources_list
+    assert result.exit_code == 0
+
+
+def test_config_remove_source_with_configuration_path(
+    cli_runner, tmp_path, mock_build_configuration_from_file, mock_configuration_path
+):
+    config_path, source = tmp_path / "statue.toml", tmp_path / SOURCE1
+    config_path.touch()
+    source.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.sources_repository[source] = CommandsFilter(allowed_commands=COMMAND3)
+    result = cli_runner.invoke(
+        statue_cli,
+        ["config", "remove-source", str(source), "--config", str(config_path)],
+        input="y\n",
+    )
+    mock_build_configuration_from_file.assert_called_once_with(config_path)
+
+    assert source not in configuration.sources_repository.sources_list
+    assert result.exit_code == 0
+
+
+def test_config_remove_non_existing_source_with_default_configuration_path(
+    cli_runner, tmp_path, mock_build_configuration_from_file, mock_configuration_path
+):
+    source = tmp_path / SOURCE1
+    source.touch()
+    result = cli_runner.invoke(
+        statue_cli, ["config", "remove-source", str(source)], input="y\n"
+    )
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 1
+    assert result.output == f"Could not find {source} in configuration.\n"
+
+
+@pytest.mark.parametrize(argnames="abort_flag", argvalues=["", "n"])
+def test_config_remove_source_abort(
+    abort_flag,
+    cli_runner,
+    tmp_path,
+    mock_build_configuration_from_file,
+    mock_configuration_path,
+):
+    source = tmp_path / SOURCE1
+    source.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.sources_repository[source] = CommandsFilter(
+        allowed_commands=[COMMAND3]
+    )
+    result = cli_runner.invoke(
+        statue_cli, ["config", "remove-source", str(source)], input=f"{abort_flag}\n"
+    )
+
+    mock_build_configuration_from_file.assert_called_once_with(
+        mock_configuration_path.return_value
+    )
+    assert result.exit_code == 0
+    assert result.output == (
+        f"Are you sure you would like to remove the source {source} "
+        f"from configuration? [y/N]: {abort_flag}\n"
+        "Abort!\n"
+    )

--- a/tests/configuration/sources_repository/test_sources_repository_basics.py
+++ b/tests/configuration/sources_repository/test_sources_repository_basics.py
@@ -96,6 +96,28 @@ def test_sources_repository_get_filter_of_unknown_source():
     assert sources_repository[Path(SOURCE2)] == CommandsFilter()
 
 
+def test_sources_repository_remove_source():
+    sources_repository = SourcesRepository()
+    commands_filter1, commands_filter2, commands_filter3 = (
+        CommandsFilter(
+            contexts=[Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)],
+            allowed_commands=[COMMAND1, COMMAND2],
+        ),
+        CommandsFilter(contexts=[Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2)]),
+        CommandsFilter(denied_commands=[COMMAND3, COMMAND4]),
+    )
+    sources_repository[Path(SOURCE1)] = commands_filter1
+    sources_repository[Path(SOURCE2)] = commands_filter2
+    sources_repository[Path(SOURCE3)] = commands_filter3
+
+    sources_repository.remove_source(Path(SOURCE2))
+
+    assert len(sources_repository) == 2
+    assert sources_repository.sources_list == [Path(SOURCE1), Path(SOURCE3)]
+    assert sources_repository[Path(SOURCE1)] == commands_filter1
+    assert sources_repository[Path(SOURCE3)] == commands_filter3
+
+
 def test_sources_repository_reset():
     sources_repository = SourcesRepository()
     sources_repository[Path(SOURCE1)] = CommandsFilter(


### PR DESCRIPTION
**Description**
Sources can now be added, removed and edited via command line

**Tests**
Added relevant unit tests and ran `statue config` with the new commands

**Alternatives**
Not relevant

**Additional context**
Python version (should be 3.7 or higher): 3.9
Operating system (Windows, Linux, Max, etc.): Windows
Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
Any other context or screenshots you think may be beneficial:
