### PR TITLE
Ellaborate context specification

### DIFF
--- a/src/statue/cli/commands.py
+++ b/src/statue/cli/commands.py
@@ -75,12 +75,23 @@ def show_command_cli(
         click.echo(
             f"{bullet_style('Allowed contexts')} - " f"{', '.join(allowed_contexts)}"
         )
-    if len(command_builder.specified_contexts) != 0:
-        specified_contexts = [
-            name_style(context.name) for context in command_builder.specified_contexts
-        ]
-        specified_contexts.sort()
-        click.echo(
-            f"{bullet_style('Specified contexts')} - "
-            f"{', '.join(specified_contexts)}"
-        )
+    if len(command_builder.specified_contexts) == 0:
+        return
+    click.echo(f"{bullet_style('Specified contexts')}:")
+    for (
+        context,
+        context_specification,
+    ) in command_builder.contexts_specifications.items():
+        click.echo(f"\t{name_style(context.name)}")
+        if context_specification.args is not None:
+            click.echo(
+                f"\t\t{bullet_style('Override arguments')}: "
+                f"{' '.join(context_specification.args)}"
+            )
+        if context_specification.add_args is not None:
+            click.echo(
+                f"\t\t{bullet_style('Added arguments')}: "
+                f"{' '.join(context_specification.add_args)}"
+            )
+        if context_specification.clear_args:
+            click.echo(f"\t\t{bullet_style('Clears arguments')}")

--- a/src/statue/cli/commands.py
+++ b/src/statue/cli/commands.py
@@ -61,7 +61,7 @@ def show_command_cli(
         )
     if len(command_builder.required_contexts) != 0:
         required_contexts = [
-            context.name for context in command_builder.required_contexts
+            name_style(context.name) for context in command_builder.required_contexts
         ]
         required_contexts.sort()
         click.echo(
@@ -69,7 +69,7 @@ def show_command_cli(
         )
     if len(command_builder.allowed_contexts) != 0:
         allowed_contexts = [
-            context.name for context in command_builder.allowed_contexts
+            name_style(context.name) for context in command_builder.allowed_contexts
         ]
         allowed_contexts.sort()
         click.echo(
@@ -77,7 +77,7 @@ def show_command_cli(
         )
     if len(command_builder.specified_contexts) != 0:
         specified_contexts = [
-            context.name for context in command_builder.specified_contexts
+            name_style(context.name) for context in command_builder.specified_contexts
         ]
         specified_contexts.sort()
         click.echo(

--- a/tests/cli/test_command_cli.py
+++ b/tests/cli/test_command_cli.py
@@ -114,21 +114,18 @@ def test_commands_show_command_with_allowed_contexts(
     ), "Show output is different than expected."
 
 
-def test_commands_show_command_with_specified_contexts(
+def test_commands_show_command_with_arguments_override_specified_context(
     cli_runner, mock_build_configuration_from_file
 ):
     configuration = mock_build_configuration_from_file.return_value
-    context1, context2 = (
-        Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1),
-        Context(name=CONTEXT2, help=CONTEXT_HELP_STRING2),
-    )
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
     configuration.commands_repository.add_command_builders(
         CommandBuilder(
             COMMAND2,
             help=COMMAND_HELP_STRING2,
+            default_args=[ARG1, ARG2],
             contexts_specifications={
-                context1: ContextSpecification(args=[ARG1]),
-                context2: ContextSpecification(add_args=[ARG2]),
+                context1: ContextSpecification(args=[ARG3, ARG4]),
             },
         )
     )
@@ -137,7 +134,64 @@ def test_commands_show_command_with_specified_contexts(
     assert result.output == (
         f"Name - {COMMAND2}\n"
         f"Description - {COMMAND_HELP_STRING2}\n"
-        f"Specified contexts - {CONTEXT1}, {CONTEXT2}\n"
+        f"Default arguments - {ARG1} {ARG2}\n"
+        "Specified contexts:\n"
+        f"\t{CONTEXT1}\n"
+        f"\t\tOverride arguments: {ARG3} {ARG4}\n"
+    ), "Show output is different than expected."
+
+
+def test_commands_show_command_with_arguments_added_specified_context(
+    cli_runner, mock_build_configuration_from_file
+):
+    configuration = mock_build_configuration_from_file.return_value
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    configuration.commands_repository.add_command_builders(
+        CommandBuilder(
+            COMMAND2,
+            help=COMMAND_HELP_STRING2,
+            default_args=[ARG1, ARG2],
+            contexts_specifications={
+                context1: ContextSpecification(add_args=[ARG3, ARG4]),
+            },
+        )
+    )
+    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    assert result.exit_code == 0, f"Exited with exception: {result.exception}"
+    assert result.output == (
+        f"Name - {COMMAND2}\n"
+        f"Description - {COMMAND_HELP_STRING2}\n"
+        f"Default arguments - {ARG1} {ARG2}\n"
+        "Specified contexts:\n"
+        f"\t{CONTEXT1}\n"
+        f"\t\tAdded arguments: {ARG3} {ARG4}\n"
+    ), "Show output is different than expected."
+
+
+def test_commands_show_command_with_clear_arguments_specified_context(
+    cli_runner, mock_build_configuration_from_file
+):
+    configuration = mock_build_configuration_from_file.return_value
+    context1 = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1)
+    configuration.commands_repository.add_command_builders(
+        CommandBuilder(
+            COMMAND2,
+            help=COMMAND_HELP_STRING2,
+            default_args=[ARG1, ARG2],
+            contexts_specifications={
+                context1: ContextSpecification(clear_args=True),
+            },
+        )
+    )
+    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    assert result.exit_code == 0, f"Exited with exception: {result.exception}"
+    assert result.output == (
+        f"Name - {COMMAND2}\n"
+        f"Description - {COMMAND_HELP_STRING2}\n"
+        f"Default arguments - {ARG1} {ARG2}\n"
+        "Specified contexts:\n"
+        f"\t{CONTEXT1}\n"
+        "\t\tClears arguments\n"
     ), "Show output is different than expected."
 
 
@@ -176,7 +230,11 @@ def test_commands_show_command_with_multiple_contexts(
         f"Default arguments - {ARG1} {ARG2}\n"
         f"Required contexts - {CONTEXT1}, {CONTEXT2}\n"
         f"Allowed contexts - {CONTEXT3}, {CONTEXT4}\n"
-        f"Specified contexts - {CONTEXT5}, {CONTEXT6}\n"
+        "Specified contexts:\n"
+        f"\t{CONTEXT5}\n"
+        f"\t\tOverride arguments: {ARG3}\n"
+        f"\t{CONTEXT6}\n"
+        f"\t\tAdded arguments: {ARG4}\n"
     ), "Show output is different than expected."
 
 


### PR DESCRIPTION
**Description**
When running `statue commands show`, we should elaborate on the contexts specifications and tell what they change with the arguments of the command

**Tests**
Added relevant unit tests and ran `statue command show`

**Alternatives**
Not relevant

**Additional context**
- Python version (should be 3.7 or higher): 3.9
- Operating system (Windows, Linux, Mac, etc.): Windows
- Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
- Any other context or screenshots you think may be beneficial:
