### PR TITLE
Document contexts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,8 @@ when you have large codebase that you want to migrate to a given style one step 
 Statue helps you to improve your code using these powerful features:
 
 - Run several formatters and linters asynchronously for faster evaluations
-- Run formatters and linters with different arguments on each file and directory using contexts
+- Run formatters and linters with different arguments on each file and directory
+using [contexts](contexts.md)
 - Avoid editing tedious configuration files by using the `statue config` cli
 - Keeping results history in order to re-run failing and non-failing static code analysis tools with only few
 keystrokes

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Statue helps you to improve your code using these powerful features:
 - Avoid editing tedious configuration files by using the `statue config` cli
 - Keeping results history in order to re-run failing and non-failing static code analysis tools with only few
 keystrokes
+- Saving your configuration as template in order for reuse in other project
 - Provide clear and concise exportable evaluation reports of all your formatters and linters
 
 ## Can't I just keep all my configurations in *setup.cfg* or *pyproject.toml*?

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -1,0 +1,127 @@
+# It's All A Matter of Context
+
+## What's Context?
+
+Contexts are the way of *Statue* to declare that a command (or multiple commands) should be running with different
+arguments than the default ones. By presenting a context you can inform *Statue* what kind of checks you want your
+linters to run or avoid running, and how to address each source in your codebase.
+
+## The Power Of Contexts
+
+The use of contexts presents few major advantages:
+
+* Using the same context name for multiple formatters and linters allows you to change the arguments of huge number
+of commands with a single magic word
+* Assigning a context to a source helps you to direct the formatters and linters how to
+run on that particular source.
+* Turning commands on and off when introducing a context which they don't comply with.
+* Joining few contexts together allows you to express complex specifications for a given command or source
+* Parenting context makes it easy to demonstrate increasingly specific requirements for a given command or source
+
+Using contexts wisely when running *Statue* can help you to reduce time spent on code reviews and broken CI processes.
+Just run *Statue* with the right contexts, and *Statue* will take it from there.
+
+On the next few paragraph, we'll show you how to do exactly that.
+
+## Presenting A Context on Specific Run
+
+If you want to run *Statue* with a context, simply run:
+
+    statue run -c your_context_name
+
+if you want to see which contexts are available, run:
+
+    statue context list
+
+## It's A Game Changer!
+
+If you want to see how a context affect your commands, simply run:
+
+    statue contexts show your_context_name
+
+After that, you'll see that the context can affect commands in three ways:
+
+* *Allowed by*: If a context is allowed by a commands, it means that the command will
+run the same way when this context is presented without changing its arguments
+* *Required by*: If a context is required by a command, it means that the command will
+not run at all unless the context is presented
+* *Specified for*: If a context is specified for a command, it means that presenting this
+context will change the arguments of the command.
+
+If you want to see exactly how a specified context change the arguments of a command,
+simply run:
+
+    statue commands show your_command_name
+
+As you'll see, a context can change a command in 3 ways:
+
+* *Override arguments*: Override all existing arguments and replace them with new ones
+* *Add arguments*: Keep all existing arguments, but add new ones at the end of the command
+* *Clear arguments* Remove all arguments of the command
+
+Different contexts can change a command in different ways. Be sure to use the right context
+in the right situation to elevate your code writing routines.
+
+## Keeping It Together
+
+As mentioned before, one can choose to use multiple contexts simultaneously.
+Just run the following command with all the contexts you want *Statue* to apply:
+
+    statue run -c context1 -c context2 ...
+
+Now, *Statue* will run with all the presented contexts. Contexts that are allowed or required
+by a command will not change the arguments of this command. However, contexts that are
+specified for a command will change the arguments **according to the order that they are
+presented in the command line**.
+
+Here's an example: assume that *context1* adds the arguments "a", "b" and "c" to the command
+*my_command* and *context2* clears the arguments entirely. By default *my_command* runs with
+the arguments "r", "t" and "s". When running:
+
+    statue run -c context1 -c context2
+
+*my_command* will run without any arguments, since it first added "a", "b" and "c", and then
+cleared all the arguments, including the ones added by *context1*. However, if you run:
+
+    statue run -c context2 -c context1
+
+*my_command* will run with the arguments "a", "b" and "c", since it first cleared all arguments
+(and removed "r", "t" and "s") and then added "a", "b" and "c".
+
+On the contrary, if both of your context simple add arguments, and the command is invariant
+to the order to arguments, than changing the order to contexts will not affect the end result
+of the command run.
+
+## Special Treatment
+
+One of the most common uses one might use contexts for is to inform commands to run
+differently on sources. This is done by editing *Statue*'s configuration file.
+
+## Example 1: The "Format" Context
+
+If you're using *Statue*'s default template than by default all the formatters are in "check"
+mode. That means that they will not change your source code when using `statue run`, but return
+an error code if your code does not match their format.
+
+If you want the formatters to format your code, you must use the "format" context.
+You can do it by running:
+
+    statue run -c format
+
+## Example 2: The "Test" Context
+
+Most linters use the same heuristics to check all of your codebase, while normally allowing you
+to ignore specific regular expressions or entire files and directories.
+However, you might want to keep running the linters on all of your codebase, just with different checks
+on different sources.
+
+A good example for that is unit tests. *Pylint* requires by default that every function will be given a
+docstring. However, most developers agree that unit test functions don't have to include docstrings since their titles
+should be meaningful enough. This is where the "test" context come in handly.
+
+By adding the "test" context to your unit tests' directory, *Statue* will remove checks that
+are not required for unit tests. You can do it by editing the configuration file.
+
+## What's next?
+- Learn how to edit the configuration file via the command line
+- Learn about the default template and what contexts and commands are available in it

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -38,4 +38,5 @@ And all the formatters and linters defined in the configuration will run on your
 
 ## What's Next?
 - Learn how to use `statue run` in various ways to [improve efficiency](run_efficiently.md)
-- Learn how to use contexts in order to specify the way you want your formatters and linters to run
+- Learn how to use [contexts](contexts.md) in order to specify the way you want your formatters
+and linters to run

--- a/docs/run_efficiently.md
+++ b/docs/run_efficiently.md
@@ -95,4 +95,5 @@ Or:
 
 
 ## What's Next?
-- Learn how to use contexts in order to specify the way you want your formatters and linters to run
+- Learn how to use [contexts](contexts.md) in order to specify the way you want
+your formatters and linters to run

--- a/docs/run_efficiently.md
+++ b/docs/run_efficiently.md
@@ -80,7 +80,7 @@ If you want to only run the failed commands from the last failed evaluation, run
 
     statue run -fo
 
-If you want to re-run a specific evaluation from history, You can do so by using the `-p` flag
+If you want to re-run a specific evaluation from history, You can do so by using the `-p` flag.
 For example, if you want to re-run evaluation 6 from before, you can do so by running:
 
     statue run -p 6

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Tutorials:
       - Quick Start: quick_start.md
       - Run Efficiently: run_efficiently.md
+      - It's All A Matter of Context: contexts.md
 plugins:
   - macros:
       module_name: docs/mkdocs_macros


### PR DESCRIPTION
**Description**
Add contexts to documentation.

**Tests**
Ran `mkdocs serve` and saw that everything is working orrectly.

**Alternatives**
Not relevant

**Additional context**
- Python version (should be 3.7 or higher): 3.9
- Operating system (Windows, Linux, Mac, etc.): Windows
- Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
- Any other context or screenshots you think may be beneficial:
