### PR TITLE
Document configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,15 +16,15 @@ unwanted conflicts. With *Statue* you can integrate tools such as *Mypy*, *Pylin
 
 ## What Do You Mean by "Orchestration"?
 
-When running multiple formatters and linters, sometimes they interfere with each other and cause clashes.
-On other occasions, in order to solve an issue with one linter you have to introduce another issue
+When running multiple formatters and linters (commands, in general), sometimes they interfere with each other and
+cause clashes. On other occasions, in order to solve an issue with one linter you have to introduce another issue
 in a different linter. 
 
 *Statue* solves this problem (and many other problems, as we'll describe later) by keeping all
 your linters and formatters configuration in one file, which is fully editable via command line. In that way,
-you won't need to edit huge configuration files in order to keep your formatters and linters in check.
+you won't need to edit huge configuration files in order to keep your commands in check.
 
-Moreover, With *Statue* you can define different arguments for your formatters and linters to use on each file
+Moreover, With *Statue* you can define different arguments for your commands to use on each file
 and directory in your codebase. This allows you to customize different style conventions for different files and
 directories, making your work with static code analysis tools more robust and user-friendly. This can be very handy
 when you have large codebase that you want to migrate to a given style one step at a time.  
@@ -34,7 +34,7 @@ when you have large codebase that you want to migrate to a given style one step 
 Statue helps you to improve your code using these powerful features:
 
 - Run several formatters and linters asynchronously for faster evaluations
-- Run formatters and linters with different arguments on each file and directory
+- Run commands with different arguments on each file and directory
 using [contexts](contexts.md)
 - Avoid editing tedious configuration files by using the `statue config` cli
 - Keeping results history in order to re-run failing and non-failing static code analysis tools with only few

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ Statue helps you to improve your code using these powerful features:
 - Run several formatters and linters asynchronously for faster evaluations
 - Run commands with different arguments on each file and directory
 using [contexts](contexts.md)
-- Avoid editing tedious configuration files by using the `statue config` cli
+- Avoid editing tedious configuration files by using the `statue config` command
 - Keeping results history in order to re-run failing and non-failing static code analysis tools with only few
 keystrokes
 - Saving your configuration as template in order for reuse in other project
@@ -49,7 +49,7 @@ While this solution does help keep all your configuration in one place, it doesn
 configurations for different files and directories.
 
 While *Statue* does introduce an additional configuration file (*statue.toml*), this configuration file is totally
-editable via command line using the `statue config` methods.
+[editable via command line](configuration.md) using the `statue config` methods.
 
 ## How does *Statue* differ from *pre-commit*?
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,65 @@
+# Configurate It
+
+*Statue*, like any other static code analysis tool, uses a configuration file to specify how it should operate.
+This file is *statue.toml*, and it is the file that has been created when you ran `statue config init`
+in the [quick start](quick_start.md) manual.
+
+In the next few paragraphs we'll show you how to edit your configuration in order to add new contexts and
+commands, and how to let *Statue* know which sources to track and with which contexts and commands to operate on
+each of them.
+
+!!! note
+
+    At the moment *Statue* does not support using *setup.cfg* and *pyproject.toml* as its configuration file.
+    This feature might be considered in the future.
+
+## What The Configuration is Made of?
+
+*Statue*'s Configuration is made of 4 sections:
+
+- **General Settings** - general *Statue* settings including history size and runner mode
+- **Contexts Settings** - list of all available [contexts](contexts.md)
+- **Commands Settings** - list of all available commands, including context specifications
+- **Sources Settings** - list of all tracked sources, including which contexts to apply on them, which commands
+to allow running on them and which commands to deny.
+
+We will go through each section in a moment.
+
+## Edit Via Command Line, Not Configuration File
+
+One major difference between *Statue* and other static code analysis tools is that statue
+encourages you to never edit your configuration file manually. Instead, *Statue*'s
+configuration file is fully editable via command line using the `statue config` commands.
+
+The reason we don't recommend editing the configuration file manually is that by using
+`statue config`, *Statue* can make sure that there are no conflicts in the configuration file.
+If some of those conflicts emerge when you edit your configuration, *Statue* will ask you
+to re-enter some fields you've filled, or it will abort.
+
+!!! warning
+
+    Like all other static code analysis tools, *Statue* does not save configuration file history.
+    Therefore, unless you're using a VCS tool like git to track *statue.toml* changes, we
+    highly recommend editing the configuration carefully. 
+
+## Configuration Initialization
+
+By now you're already familiar with the command `statue config init`. This command creates the configuration file
+*statue.toml* with default contexts and commands.
+
+If you didn't run `statue config init` already, now would be the perfect time to do so before
+you start editing the configuration file.
+
+## Editing the Configuration
+
+It's as simple as it can get! Just run `statue config --help` and see which commands you
+can use to edit the configuration file.
+
+For example, you can run `statue config add-context` in order to add a new context to
+configuration. Just follow the instruction and the new context will be added!
+
+!!! warning
+
+    Pay attention that using the `remove-context`, `remove-command` and `remove-source` commands will
+    remove the specified context, command and source respectively, **including all of their
+    references!**

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -10,9 +10,9 @@ linters to run or avoid running, and how to address each source in your codebase
 
 The use of contexts presents few major advantages:
 
-* Using the same context name for multiple formatters and linters allows you to change the arguments of huge number
+* Using the same context name for multiple commands allows you to change the arguments of huge number
 of commands with a single magic word
-* Assigning a context to a source helps you to direct the formatters and linters how to
+* Assigning a context to a source helps you to direct the commands how to
 run on that particular source.
 * Turning commands on and off when introducing a context which they don't comply with.
 * Joining few contexts together allows you to express complex specifications for a given command or source

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -123,5 +123,5 @@ By adding the "test" context to your unit tests' directory, *Statue* will remove
 are not required for unit tests. You can do it by editing the configuration file.
 
 ## What's next?
-- Learn how to edit the configuration file via the command line
+- Learn how to edit the [configuration](configuration.md) file via the command line
 - Learn about the default template and what contexts and commands are available in it

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -42,7 +42,7 @@ Now that your configuration file is ready, simply run:
 
     statue run
    
-And all the formatters and linters defined in the configuration will run on your codebase.
+And all the commands defined in the configuration will run on your codebase.
 
 !!! note
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -54,3 +54,4 @@ And all the commands defined in the configuration will run on your codebase.
 - Learn how to use `statue run` in various ways to [improve efficiency](run_efficiently.md)
 - Learn how to use [contexts](contexts.md) in order to specify the way you want your formatters
 and linters to run
+- Learn how to edit your [configuration](configuration.md) file via command line

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -15,12 +15,14 @@ Which will print:
 
 ## Initialize *Statue*
 
-In order for *Statue* to work correctly, you need to initialize *statue.toml* configuration file.
-This is simply done using the command:
+In order for *Statue* to work correctly, you need to initialize *Statue*'s configuration file.
+This is simply done going to your project's root directory and using the command:
 
     statue config init
 
-Just follow the instructions, and your *Statue* configuration file will be ready!
+This command will create *statue.toml* file with the relevant configurations. Just follow the instructions, and your
+*Statue* configuration file will be ready!
+
 You can see which commands have been set in your configuration using the command:
 
     statue config show-tree
@@ -29,12 +31,24 @@ If you want to look at your configuration file as plain text, you can alternativ
 
     statue config show
 
+!!! note
+
+    When using `statue config init`, *Statue* will ask you to specify for each source which [contexts](contexts.md),
+    allowed commands and denied commands to apply to that source. If you are not sure how to respond, skip by pressing
+    enter. You'll always be able to edit your configuration later.
+
 ## Run!
 Now that your configuration file is ready, simply run:
 
     statue run
    
 And all the formatters and linters defined in the configuration will run on your codebase.
+
+!!! note
+
+    When running `statue run`, *Statue* creates a cache directory named *.statue* which is saved in your project's
+    root directory. If you're using *git* as your VCS tool we highly recommend that you add *.statue* to your
+    *.gitignore* file. 
 
 ## What's Next?
 - Learn how to use `statue run` in various ways to [improve efficiency](run_efficiently.md)

--- a/docs/run_efficiently.md
+++ b/docs/run_efficiently.md
@@ -5,7 +5,9 @@ The simplest way you can run *Statue* is to use the following command:
 
     statue run
 
-This will run all formatters and linters in your configuration on your codebase. This will result in two ways:
+This will run all available commands from your configuration on your codebase.
+
+Running this command will result in two ways:
 
 If the run finished successfully, the following will be printed:
 
@@ -96,4 +98,4 @@ Or:
 
 ## What's Next?
 - Learn how to use [contexts](contexts.md) in order to specify the way you want
-your formatters and linters to run
+your commands to run

--- a/docs/run_efficiently.md
+++ b/docs/run_efficiently.md
@@ -5,7 +5,7 @@ The simplest way you can run *Statue* is to use the following command:
 
     statue run
 
-This will run all available commands from your configuration on your codebase.
+This will run all available commands from your [configuration](configuration.md) on your codebase.
 
 Running this command will result in two ways:
 
@@ -99,3 +99,5 @@ Or:
 ## What's Next?
 - Learn how to use [contexts](contexts.md) in order to specify the way you want
 your commands to run
+- Learn how to add new commands and edit existing ones in your [configuration](configuration.md)
+using only the command line

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,8 @@ nav:
       - Quick Start: quick_start.md
       - Run Efficiently: run_efficiently.md
       - It's All A Matter of Context: contexts.md
+markdown_extensions:
+  - admonition
 plugins:
   - macros:
       module_name: docs/mkdocs_macros

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
       - Quick Start: quick_start.md
       - Run Efficiently: run_efficiently.md
       - It's All A Matter of Context: contexts.md
+      - Configurate It: configuration.md
 markdown_extensions:
   - admonition
 plugins:


### PR DESCRIPTION
**Description**
Add configuration documentation

**Tests**
Ran `mkdocs serve` and aw the new page

**Alternatives**
Not relevant

**Additional context**
- Python version (should be 3.7 or higher): 3.9
- Operating system (Windows, Linux, Mac, etc.): Windows
- Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
- Any other context or screenshots you think may be beneficial:
