### PR TITLE
Add blank flag to config init

### DIFF
--- a/src/statue/config/configuration.py
+++ b/src/statue/config/configuration.py
@@ -312,6 +312,17 @@ class Configuration:
         return directory / ".statue"
 
     @classmethod
+    def empty_configuration(cls) -> "Configuration":
+        """
+        Creates an empty configuration.
+
+        :return: Empty configuration
+        :rtype: Configuration
+        """
+        cache = Cache(size=DEFAULT_HISTORY_SIZE)
+        return Configuration(cache=cache)
+
+    @classmethod
     def _none_or_remove(
         cls, optional_set: Optional[FrozenSet[T]], removed_item: T
     ) -> Optional[FrozenSet[T]]:

--- a/tests/cli/config/test_config_init.py
+++ b/tests/cli/config/test_config_init.py
@@ -50,6 +50,33 @@ def dummy_configuration():
     return configuration
 
 
+def test_config_init_blank(
+    cli_runner,
+    mock_configuration_path,
+    mock_build_configuration_from_file,
+    mock_templates_provider_get_template_path,
+    mock_git_repo,
+    mock_update_sources_repository,
+    mock_configuration_as_dict,
+):
+    with mock.patch.object(
+        Configuration, "empty_configuration"
+    ) as empty_configuration_mock:
+        result = cli_runner.invoke(statue_cli, ["config", "init", "--blank"])
+        empty_configuration_mock.assert_called_once_with()
+        empty_configuration_mock.return_value.to_toml.assert_called_once_with(
+            mock_configuration_path.return_value
+        )
+
+    assert result.exit_code == 0, f"Exited with exception: {result.exception}"
+    mock_configuration_path.assert_called_once_with()
+    mock_git_repo.assert_not_called()
+    mock_templates_provider_get_template_path.assert_not_called()
+    mock_build_configuration_from_file.assert_not_called()
+
+    mock_update_sources_repository.assert_not_called()
+
+
 def test_config_init_all_yes(
     cli_runner,
     mock_configuration_path,

--- a/tests/configuration/configuration/test_configuration_basics.py
+++ b/tests/configuration/configuration/test_configuration_basics.py
@@ -1,7 +1,18 @@
 import mock
 
+from statue.cache import Cache
 from statue.config.configuration import Configuration
 from statue.runner import RunnerMode
+
+
+def test_empty_configuration():
+    configuration = Configuration.empty_configuration()
+    assert isinstance(configuration.cache, Cache)
+    assert configuration.cache.history_size == 30
+    assert len(configuration.commands_repository) == 0
+    assert len(configuration.contexts_repository) == 0
+    assert len(configuration.sources_repository) == 0
+    assert configuration.default_mode == RunnerMode.SYNC
 
 
 def test_configuration_constructor_without_mode(tmp_path):


### PR DESCRIPTION
**Description**
Removed the blank template and added `--blank` flag to `statue config init` to create blank  configuration

**Tests**
Added relevant unit tests and checked that `statue config init --blank` works

**Alternatives**
Keep the "blank" template. This seems like a little bit overkill.

**Additional context**
- Python version (should be 3.7 or higher): 3.9
- Operating system (Windows, Linux, Mac, etc.): Windows
- Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
- Any other context or screenshots you think may be beneficial:
