### PR TITLE
Rename CLI groups

### DIFF
--- a/src/statue/cli/commands.py
+++ b/src/statue/cli/commands.py
@@ -8,7 +8,7 @@ from statue.config.configuration import Configuration
 from statue.exceptions import UnknownCommand
 
 
-@statue_cli.group("command")
+@statue_cli.group("commands")
 def commands_cli() -> None:
     """Commands related actions such as list, install, show, etc."""
 

--- a/src/statue/cli/contexts.py
+++ b/src/statue/cli/contexts.py
@@ -8,7 +8,7 @@ from statue.config.configuration import Configuration
 from statue.exceptions import UnknownContext
 
 
-@statue_cli.group("context")
+@statue_cli.group("contexts")
 def context_cli() -> None:
     """Contexts related actions such as list, show, etc."""
 

--- a/tests/cli/test_cli_basics.py
+++ b/tests/cli/test_cli_basics.py
@@ -9,7 +9,7 @@ from statue.exceptions import (
 )
 
 
-@parametrize(argnames="cli_command", argvalues=[["command", "list"], ["run"]])
+@parametrize(argnames="cli_command", argvalues=[["commands", "list"], ["run"]])
 @parametrize(
     argnames="config_error",
     argvalues=[

--- a/tests/cli/test_command_cli.py
+++ b/tests/cli/test_command_cli.py
@@ -44,7 +44,7 @@ def test_commands_list(cli_runner, mock_build_configuration_from_file):
         CommandBuilder(COMMAND3, help=COMMAND_HELP_STRING3),
         CommandBuilder(COMMAND4, help=COMMAND_HELP_STRING4),
     )
-    result = cli_runner.invoke(statue_cli, ["command", "list"])
+    result = cli_runner.invoke(statue_cli, ["commands", "list"])
     assert (
         result.exit_code == 0
     ), f"Exited unsuccessfully with the following exception: {result.exception}"
@@ -61,7 +61,7 @@ def test_commands_show_simple_command(cli_runner, mock_build_configuration_from_
     configuration.commands_repository.add_command_builders(
         CommandBuilder(COMMAND2, help=COMMAND_HELP_STRING2, default_args=[ARG3])
     )
-    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    result = cli_runner.invoke(statue_cli, ["commands", "show", COMMAND2])
     assert result.exit_code == 0, f"Exited with exception: {result.exception}"
     assert result.output == (
         f"Name - {COMMAND2}\n"
@@ -83,7 +83,7 @@ def test_commands_show_command_with_required_contexts(
             COMMAND2, help=COMMAND_HELP_STRING2, required_contexts=[context1, context2]
         )
     )
-    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    result = cli_runner.invoke(statue_cli, ["commands", "show", COMMAND2])
     assert result.exit_code == 0, f"Exited with exception: {result.exception}"
     assert result.output == (
         f"Name - {COMMAND2}\n"
@@ -105,7 +105,7 @@ def test_commands_show_command_with_allowed_contexts(
             COMMAND2, help=COMMAND_HELP_STRING2, allowed_contexts=[context1, context2]
         )
     )
-    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    result = cli_runner.invoke(statue_cli, ["commands", "show", COMMAND2])
     assert result.exit_code == 0, f"Exited with exception: {result.exception}"
     assert result.output == (
         f"Name - {COMMAND2}\n"
@@ -129,7 +129,7 @@ def test_commands_show_command_with_arguments_override_specified_context(
             },
         )
     )
-    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    result = cli_runner.invoke(statue_cli, ["commands", "show", COMMAND2])
     assert result.exit_code == 0, f"Exited with exception: {result.exception}"
     assert result.output == (
         f"Name - {COMMAND2}\n"
@@ -156,7 +156,7 @@ def test_commands_show_command_with_arguments_added_specified_context(
             },
         )
     )
-    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    result = cli_runner.invoke(statue_cli, ["commands", "show", COMMAND2])
     assert result.exit_code == 0, f"Exited with exception: {result.exception}"
     assert result.output == (
         f"Name - {COMMAND2}\n"
@@ -183,7 +183,7 @@ def test_commands_show_command_with_clear_arguments_specified_context(
             },
         )
     )
-    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    result = cli_runner.invoke(statue_cli, ["commands", "show", COMMAND2])
     assert result.exit_code == 0, f"Exited with exception: {result.exception}"
     assert result.output == (
         f"Name - {COMMAND2}\n"
@@ -222,7 +222,7 @@ def test_commands_show_command_with_multiple_contexts(
             },
         )
     )
-    result = cli_runner.invoke(statue_cli, ["command", "show", COMMAND2])
+    result = cli_runner.invoke(statue_cli, ["commands", "show", COMMAND2])
     assert result.exit_code == 0, f"Exited with exception: {result.exception}"
     assert result.output == (
         f"Name - {COMMAND2}\n"
@@ -241,7 +241,7 @@ def test_commands_show_command_with_multiple_contexts(
 def test_commands_show_unknown_command_side_effect(
     cli_runner, mock_build_configuration_from_file
 ):
-    result = cli_runner.invoke(statue_cli, ["command", "show", NOT_EXISTING_COMMAND])
+    result = cli_runner.invoke(statue_cli, ["commands", "show", NOT_EXISTING_COMMAND])
     assert result.exit_code == 1, "show command should exit with failure."
     assert (
         result.output == f'Could not find command named "{NOT_EXISTING_COMMAND}"\n'
@@ -259,7 +259,7 @@ def test_command_install_with_default_verbosity(
     configuration = Configuration(cache=mock.Mock())
     configuration.commands_repository.add_command_builders(*command_builders)
     mock_build_configuration_from_file.return_value = configuration
-    result = cli_runner.invoke(statue_cli, ["command", "install"])
+    result = cli_runner.invoke(statue_cli, ["commands", "install"])
     for command_builder in command_builders:
         command_builder.install.assert_called_once_with(verbosity=DEFAULT_VERBOSITY)
     assert result.exit_code == 0, "Show command returned with no success code"
@@ -274,7 +274,7 @@ def test_command_install_with_verbose(cli_runner, mock_build_configuration_from_
     configuration = Configuration(cache=mock.Mock())
     configuration.commands_repository.add_command_builders(*command_builders)
     mock_build_configuration_from_file.return_value = configuration
-    result = cli_runner.invoke(statue_cli, ["command", "install", "--verbose"])
+    result = cli_runner.invoke(statue_cli, ["commands", "install", "--verbose"])
     for command_builder in command_builders:
         command_builder.install.assert_called_with(verbosity=VERBOSE)
     assert result.exit_code == 0, "Show command returned with no success code"
@@ -295,7 +295,7 @@ def test_command_install_only_uninstalled(
         command_builder1, command_builder2, command_builder3
     )
     mock_build_configuration_from_file.return_value = configuration
-    result = cli_runner.invoke(statue_cli, ["command", "install", "--verbose"])
+    result = cli_runner.invoke(statue_cli, ["commands", "install", "--verbose"])
     command_builder1.install.assert_not_called()
     command_builder2.install.assert_called_with(verbosity=VERBOSE)
     command_builder3.install.assert_called_with(verbosity=VERBOSE)

--- a/tests/cli/test_context_cli.py
+++ b/tests/cli/test_context_cli.py
@@ -42,7 +42,7 @@ def test_contexts_list_of_full_configuration(
         Context(name=CONTEXT4, help=CONTEXT_HELP_STRING4),
         Context(name=CONTEXT5, help=CONTEXT_HELP_STRING5),
     )
-    result = cli_runner.invoke(statue_cli, ["context", "list"])
+    result = cli_runner.invoke(statue_cli, ["contexts", "list"])
     assert result.exit_code == 0, "list contexts should exit with success."
     assert result.output == (
         f"{CONTEXT1} - {CONTEXT_HELP_STRING1}\n"
@@ -56,7 +56,7 @@ def test_contexts_list_of_full_configuration(
 def test_contexts_list_of_an_empty_configuration(
     cli_runner, mock_build_configuration_from_file
 ):
-    result = cli_runner.invoke(statue_cli, ["context", "list"])
+    result = cli_runner.invoke(statue_cli, ["contexts", "list"])
     assert result.exit_code == 1, "list contexts should exit with failure."
     assert (
         result.output == "No contexts were found.\n"
@@ -72,7 +72,7 @@ def test_contexts_show_simple_context(cli_runner, mock_build_configuration_from_
         Context(name=CONTEXT4, help=CONTEXT_HELP_STRING4),
         Context(name=CONTEXT5, help=CONTEXT_HELP_STRING5),
     )
-    result = cli_runner.invoke(statue_cli, ["context", "show", CONTEXT2])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", CONTEXT2])
     assert result.exit_code == 0, "show context should exit with success."
     assert result.output == (
         f"Name - {CONTEXT2}\n" f"Description - {CONTEXT_HELP_STRING2}\n"
@@ -86,7 +86,7 @@ def test_contexts_show_context_with_one_alias(
     configuration.contexts_repository.add_contexts(
         Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, aliases=[CONTEXT2])
     )
-    result = cli_runner.invoke(statue_cli, ["context", "show", CONTEXT1])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", CONTEXT1])
     assert result.exit_code == 0, "show context should exit with success."
     assert result.output == (
         f"Name - {CONTEXT1}\n"
@@ -102,7 +102,7 @@ def test_contexts_show_context_with_two_aliases(
     configuration.contexts_repository.add_contexts(
         Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, aliases=[CONTEXT2, CONTEXT3])
     )
-    result = cli_runner.invoke(statue_cli, ["context", "show", CONTEXT1])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", CONTEXT1])
     assert result.exit_code == 0, "show context should exit with success."
     assert result.output == (
         f"Name - {CONTEXT1}\n"
@@ -118,7 +118,7 @@ def test_contexts_show_context_with_parent(
     context = Context(name=CONTEXT1, help=CONTEXT_HELP_STRING1, parent=parent)
     configuration = mock_build_configuration_from_file.return_value
     configuration.contexts_repository.add_contexts(context, parent)
-    result = cli_runner.invoke(statue_cli, ["context", "show", CONTEXT1])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", CONTEXT1])
     assert result.exit_code == 0, "show context should exit with success."
     assert result.output == (
         f"Name - {CONTEXT1}\n"
@@ -138,7 +138,7 @@ def test_contexts_show_context_required_by_command(
         )
     )
     configuration.contexts_repository.add_contexts(context)
-    result = cli_runner.invoke(statue_cli, ["context", "show", CONTEXT1])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", CONTEXT1])
     assert result.exit_code == 0, "show context should exit with success."
     assert result.output == (
         f"Name - {CONTEXT1}\n"
@@ -158,7 +158,7 @@ def test_contexts_show_context_allowed_for_command(
         )
     )
     configuration.contexts_repository.add_contexts(context)
-    result = cli_runner.invoke(statue_cli, ["context", "show", CONTEXT1])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", CONTEXT1])
     assert result.exit_code == 0, "show context should exit with success."
     assert result.output == (
         f"Name - {CONTEXT1}\n"
@@ -180,7 +180,7 @@ def test_contexts_show_context_specified_for_command(
         )
     )
     configuration.contexts_repository.add_contexts(context)
-    result = cli_runner.invoke(statue_cli, ["context", "show", CONTEXT1])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", CONTEXT1])
     assert result.exit_code == 0, "show context should exit with success."
     assert result.output == (
         f"Name - {CONTEXT1}\n"
@@ -219,7 +219,7 @@ def test_contexts_show_context_with_multiple_available_commands(
         ),
     )
     configuration.contexts_repository.add_contexts(context)
-    result = cli_runner.invoke(statue_cli, ["context", "show", CONTEXT1])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", CONTEXT1])
     assert result.exit_code == 0, "show context should exit with success."
     assert result.output == (
         f"Name - {CONTEXT1}\n"
@@ -241,7 +241,7 @@ def test_contexts_show_non_existing_context(
         Context(name=CONTEXT4, help=CONTEXT_HELP_STRING4),
         Context(name=CONTEXT5, help=CONTEXT_HELP_STRING5),
     )
-    result = cli_runner.invoke(statue_cli, ["context", "show", NOT_EXISTING_CONTEXT])
+    result = cli_runner.invoke(statue_cli, ["contexts", "show", NOT_EXISTING_CONTEXT])
     assert result.exit_code == 1, "show context should exit with failure."
     assert (
         result.output == f'Could not find the context "{NOT_EXISTING_CONTEXT}".\n'


### PR DESCRIPTION
**Description**
`command` -> `commands`
`context` -> `contexts`

**Tests**
Updated unit tests and ran changed commands

**Alternatives**
Keep groups singular. That sometimes doesn't make sense. for example, `statue commands list` is more reasonable that `statue command list`.

**Additional context**
- Python version (should be 3.7 or higher): 3.9
- Operating system (Windows, Linux, Mac, etc.): Windows
- Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
- Any other context or screenshots you think may be beneficial:
