### PR TITLE
Disable cache

### DIFF
--- a/src/statue/cache.py
+++ b/src/statue/cache.py
@@ -14,18 +14,22 @@ class Cache:
         self,
         size: int,
         cache_root_directory: Optional[Path] = None,
+        enabled: bool = True,
     ):
         """
         Initialize cache.
 
-        :param cache_root_directory: Optional root directory for caching
-        :type cache_root_directory: Optional[Path]
         :param size: Number of evaluations to save
         :type size: int
+        :param cache_root_directory: Optional root directory for caching
+        :type cache_root_directory: Optional[Path]
+        :param enabled: Whether caching is enabled or not. True by default.
+        :type enabled: bool
         """
         self._all_evaluations: Deque[Evaluation] = deque()
         self.cache_root_directory = cache_root_directory
         self.history_size = size
+        self.enabled = enabled
 
     @property
     def cache_root_directory(self) -> Optional[Path]:

--- a/src/statue/cli/config/config_general.py
+++ b/src/statue/cli/config/config_general.py
@@ -35,3 +35,27 @@ def set_history_size_cli(size, config):
     configuration.cache.history_size = size
     configuration.to_toml(config)
     click.echo("History size was successfully set!")
+
+
+@config_cli.command("enable-cache")
+@config_path_option
+def enable_cache_cli(config):
+    """Enabled caching in configuration."""
+    if config is None:
+        config = Configuration.configuration_path()
+    configuration = Configuration.from_file(config)
+    configuration.cache.enabled = True
+    configuration.to_toml(config)
+    click.echo("Caching is enabled!")
+
+
+@config_cli.command("disable-cache")
+@config_path_option
+def disable_cache_cli(config):
+    """Disabled caching in configuration."""
+    if config is None:
+        config = Configuration.configuration_path()
+    configuration = Configuration.from_file(config)
+    configuration.cache.enabled = False
+    configuration.to_toml(config)
+    click.echo("Caching is disabled!")

--- a/src/statue/cli/run.py
+++ b/src/statue/cli/run.py
@@ -150,7 +150,7 @@ def run_cli(  # pylint: disable=too-many-arguments
     if not is_silent(verbosity):
         click.echo(boxed_string("Evaluation"))
         click.echo(evaluation_string(evaluation, verbosity=verbosity))
-    if cache:
+    if cache and configuration.cache.enabled:
         configuration.cache.save_evaluation(evaluation)
     if output is not None:
         evaluation.save_as_json(output)

--- a/src/statue/config/configuration.py
+++ b/src/statue/config/configuration.py
@@ -19,6 +19,7 @@ from statue.config.commands_repository import CommandsRepository
 from statue.config.contexts_repository import ContextsRepository
 from statue.config.sources_repository import SourcesRepository
 from statue.constants import (
+    CACHE,
     COMMANDS,
     CONTEXTS,
     DEFAULT_HISTORY_SIZE,
@@ -149,6 +150,8 @@ class Configuration:
                 (HISTORY_SIZE, self.cache.history_size),
             ]
         )
+        if not self.cache.enabled:
+            general_dict[CACHE] = False
         return OrderedDict(
             [
                 (GENERAL, general_dict),
@@ -216,7 +219,10 @@ class Configuration:
         """
         general_configuration = statue_config_dict.get(GENERAL, {})
         history_size = general_configuration.get(HISTORY_SIZE, DEFAULT_HISTORY_SIZE)
-        cache = Cache(cache_root_directory=cache_dir, size=history_size)
+        cached_enabled = general_configuration.get(CACHE, True)
+        cache = Cache(
+            cache_root_directory=cache_dir, size=history_size, enabled=cached_enabled
+        )
         mode = RunnerMode.DEFAULT_MODE
         if MODE in general_configuration:
             mode_string = general_configuration[MODE].upper()

--- a/src/statue/constants.py
+++ b/src/statue/constants.py
@@ -25,6 +25,7 @@ ALLOWED_BY_DEFAULT = "allowed_by_default"
 VERSION = "version"
 MODE = "mode"
 HISTORY_SIZE = "history_size"
+CACHE = "cache"
 
 TEMPLATE_NAME_REGEX = r"^[A-Za-z]\w*$"
 DATETIME_FORMAT = "%m/%d/%Y, %H:%M:%S"

--- a/tests/cli/config/test_config_cache_enablement.py
+++ b/tests/cli/config/test_config_cache_enablement.py
@@ -1,0 +1,69 @@
+from statue.cli import statue_cli
+
+
+def test_config_enable_cache(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path
+):
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.enabled = False
+
+    result = cli_runner.invoke(statue_cli, ["config", "enable-cache"])
+
+    assert result.exit_code == 0
+    assert configuration.cache.enabled
+
+    mock_configuration_path.assert_called_once_with()
+    configuration.to_toml.assert_called_once_with(mock_configuration_path.return_value)
+
+
+def test_config_enable_cache_with_config_path(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path, tmp_path
+):
+    config_path = tmp_path / "statue.toml"
+    config_path.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.enabled = False
+
+    result = cli_runner.invoke(
+        statue_cli, ["config", "enable-cache", "--config", str(config_path)]
+    )
+
+    assert result.exit_code == 0
+    assert configuration.cache.enabled
+
+    mock_configuration_path.assert_not_called()
+    configuration.to_toml.assert_called_once_with(config_path)
+
+
+def test_config_disable_cache(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path
+):
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.enabled = True
+
+    result = cli_runner.invoke(statue_cli, ["config", "disable-cache"])
+
+    assert result.exit_code == 0
+    assert not configuration.cache.enabled
+
+    mock_configuration_path.assert_called_once_with()
+    configuration.to_toml.assert_called_once_with(mock_configuration_path.return_value)
+
+
+def test_config_disable_cache_with_config_path(
+    cli_runner, mock_build_configuration_from_file, mock_configuration_path, tmp_path
+):
+    config_path = tmp_path / "statue.toml"
+    config_path.touch()
+    configuration = mock_build_configuration_from_file.return_value
+    configuration.cache.enabled = True
+
+    result = cli_runner.invoke(
+        statue_cli, ["config", "disable-cache", "--config", str(config_path)]
+    )
+
+    assert result.exit_code == 0
+    assert not configuration.cache.enabled
+
+    mock_configuration_path.assert_not_called()
+    configuration.to_toml.assert_called_once_with(config_path)

--- a/tests/configuration/configuration/test_configuration_as_dict.py
+++ b/tests/configuration/configuration/test_configuration_as_dict.py
@@ -5,7 +5,15 @@ import mock
 import pytest
 
 from statue.config.configuration import Configuration
-from statue.constants import COMMANDS, CONTEXTS, GENERAL, HISTORY_SIZE, MODE, SOURCES
+from statue.constants import (
+    CACHE,
+    COMMANDS,
+    CONTEXTS,
+    GENERAL,
+    HISTORY_SIZE,
+    MODE,
+    SOURCES,
+)
 from statue.runner import RunnerMode
 
 
@@ -44,6 +52,30 @@ def test_configuration_as_dict_with_runner_mode(
     assert isinstance(configuration_dict, OrderedDict)
     assert list(configuration_dict.keys()) == [GENERAL, CONTEXTS, COMMANDS, SOURCES]
     assert configuration_dict[GENERAL] == {MODE: mode.name.lower(), HISTORY_SIZE: size}
+    assert configuration_dict[CONTEXTS] == mock_contexts_repository_as_dict.return_value
+    assert configuration_dict[COMMANDS] == mock_commands_repository_as_dict.return_value
+    assert configuration_dict[SOURCES] == mock_sources_repository_as_dict.return_value
+
+
+def test_configuration_as_dict_with_disabled_cache(
+    mock_contexts_repository_as_dict,
+    mock_commands_repository_as_dict,
+    mock_sources_repository_as_dict,
+):
+    size = random.randint(1, 100)
+    cache = mock.Mock()
+    cache.history_size = size
+    cache.enabled = False
+    configuration = Configuration(cache=cache)
+    configuration_dict = configuration.as_dict()
+
+    assert isinstance(configuration_dict, OrderedDict)
+    assert list(configuration_dict.keys()) == [GENERAL, CONTEXTS, COMMANDS, SOURCES]
+    assert configuration_dict[GENERAL] == {
+        MODE: "sync",
+        HISTORY_SIZE: size,
+        CACHE: False,
+    }
     assert configuration_dict[CONTEXTS] == mock_contexts_repository_as_dict.return_value
     assert configuration_dict[COMMANDS] == mock_commands_repository_as_dict.return_value
     assert configuration_dict[SOURCES] == mock_sources_repository_as_dict.return_value


### PR DESCRIPTION
**Description**
One can disable and enable caching via configuration

**Tests**
Added relevant tests

**Alternatives**
Use only `statue run --no-cache`. This is a bummer when you want this to happen all the time

**Additional context**
- Python version (should be 3.7 or higher): Python 3.9
- Operating system (Windows, Linux, Mac, etc.): Windows
- Statue version (0.0.1, 0.0.6dev1, latest, etc.): latets
- Any other context or screenshots you think may be beneficial:
