### PR TITLE
Run as pre commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: statue
+  name: statue
+  description: "Statue: All your static code analysis tools, in one place"
+  entry: statue run -i
+  language: python
+  minimum_pre_commit_version: 2.19.0
+  require_serial: true
+  types_or: [python, pyi]

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,17 +57,20 @@ While *Statue* does introduce an additional configuration file (*statue.toml*), 
 
 ## How does *Statue* differ from *pre-commit*?
 
-*pre-commit* has been for a long time the go-to tool for running linters and formatters on your codebase,
-and it is provided with predefined hooks for most state-of-the-art tools.
+[pre-commit](https://github.com/pre-commit/pre-commit) has been for a long time the go-to tool for running linters and
+formatters on your codebase, and it is provided with predefined hooks for most state-of-the-art tools.
 While we surely recommend on using *pre-commit*, here are few reasons why you might want to consider also
 using *Statue*:
 
 * If you don't need each and every commit to pass your linters
-* If you want to use a linters and formatters that doesn't have *.pre-commit-hooks.yaml* file
-* If you use a lot of linters and formatters which cause your `git commit` to hang for long periods of time
-* If you want to run your linters and formatters with different arguments on different files and directories
+* If you want to use a command that doesn't have *.pre-commit-hooks.yaml* file
+* If you use a lot of commands which cause your `git commit` to hang for long periods of time
+* If you want to run your commands with different arguments on different files and directories
 * If you need clear and concise reports of your linters evaluations
 
+!!! note
+
+    Psst! If you really want you can [run statue via pre-commit](integrations.md#pre-commit).
 
 ## What's next?
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,18 @@
+# Integrations
+
+Playing together is always better than playing alone. Therefore, we believe that *Statue*
+should play well with others. Here are a few tools that can be integrated with *Statue*. We are working
+towards enabling as many as integrations as possible for a collaborative ecosystem of open-source tools.
+
+## Pre-Commit
+You can use *Statue* as a [pre-commit](https://github.com/pre-commit/pre-commit) hook in order to run statue on
+every commit. You can do so by adding the following section to your *.pre-commit-config.yaml* file:
+
+```yaml
+-   repo: https://github.com/saroad2/statue
+    hooks:
+    -   id: statue
+```
+
+If you're using the default template as configuration, we highly recommend adding the `--context=fast` or
+`--context=format` flags for a quicker committing. For the other checks you can run *Statue* directly.  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - User Templates: advanced/user_templates.md
   - CLI References: cli_references.md
   - Templates: templates.md
+  - Integrations: integrations.md
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
**Description**
Fixes #195 

*Statue* can now be run as a [pre-commit hook](https://github.com/pre-commit/pre-commit)

**Tests**
Used `pre-commit try-repo` and so that it ran as expected.

**Alternatives**
Avoid integration with *pre-commit*. We like playing with others 😄 

**Additional context**
- Python version (should be 3.7 or higher): 3.9
- Operating system (Windows, Linux, Mac, etc.): Windows
- Statue version (0.0.1, 0.0.6dev1, latest, etc.): latest
- Any other context or screenshots you think may be beneficial:
